### PR TITLE
Make RoundRobinNodeSelector thread-safe

### DIFF
--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/KtorRestClient.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/KtorRestClient.kt
@@ -23,7 +23,7 @@ class KtorRestClient(
     private val password: String? = null,
     private val logging: Boolean = false,
     private val client: HttpClient = defaultKtorHttpClient(logging=logging,user=user, password = password),
-    private val nodeSelector: NodeSelector = RoundRobinNodeSelector(),
+    private val nodeSelector: NodeSelector = RoundRobinNodeSelector(nodes),
 ) : RestClient {
     constructor(
         host: String = "localhost",
@@ -42,7 +42,7 @@ class KtorRestClient(
         nodes= arrayOf( Node(host, port))
     )
 
-    override fun nextNode(): Node = nodeSelector.selectNode(nodes)
+    override fun nextNode(): Node = nodeSelector.selectNode()
 
     override suspend fun doRequest(
         pathComponents: List<String>,

--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/Restclient.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/Restclient.kt
@@ -4,7 +4,7 @@ import io.ktor.http.*
 
 data class Node(val host: String, val port: Int)
 interface NodeSelector {
-    fun selectNode(initialNodes: Array<out Node>): Node
+    fun selectNode(): Node
 }
 
 /**

--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/RoundRobinNodeSelector.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/RoundRobinNodeSelector.kt
@@ -2,12 +2,14 @@ package com.jillesvangurp.ktsearch
 
 import kotlin.native.concurrent.ThreadLocal
 
-class RoundRobinNodeSelector: NodeSelector {
+class RoundRobinNodeSelector(
+    private val nodes: Array<out Node>
+) : NodeSelector {
     @ThreadLocal
     private var index: Int = 0
-    override fun selectNode(initialNodes: Array<out Node>): Node {
-        return initialNodes[index++].also {
-            if(index > initialNodes.size-1) {
+    override fun selectNode(): Node {
+        return nodes[index++].also {
+            if(index > nodes.size-1) {
                 index=0
             }
         }

--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/RoundRobinNodeSelector.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/RoundRobinNodeSelector.kt
@@ -1,6 +1,9 @@
 package com.jillesvangurp.ktsearch
 
+import kotlin.native.concurrent.ThreadLocal
+
 class RoundRobinNodeSelector: NodeSelector {
+    @ThreadLocal
     private var index: Int = 0
     override fun selectNode(initialNodes: Array<out Node>): Node {
         return initialNodes[index++].also {


### PR DESCRIPTION
Fix for concurrency issue in the node selector. Addressing issue https://github.com/jillesvangurp/kt-search/issues/23