### PR TITLE
Fix reading REST client response

### DIFF
--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/KtorRestClient.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/KtorRestClient.kt
@@ -1,6 +1,7 @@
 package com.jillesvangurp.ktsearch
 
 import io.ktor.client.*
+import io.ktor.client.call.body
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.content.*
@@ -85,7 +86,7 @@ class KtorRestClient(
             }
         }
 
-        val responseBody = response.readBytes()
+        val responseBody = response.body<ByteArray>()
         return when (response.status) {
             HttpStatusCode.OK -> RestResponse.Status2XX.OK(responseBody)
             HttpStatusCode.Created -> RestResponse.Status2XX.Created(responseBody)


### PR DESCRIPTION
When reading raw bytes the response pipeline is circumvented and leads to problems procesing the response. For example when the `ContentEncoding` plugin is used the response is compressed.