### PR TITLE
Fix OS1/OS2 typo

### DIFF
--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/root-api.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/root-api.kt
@@ -39,7 +39,7 @@ data class SearchEngineInformation(
             when {
                 // opensearch added the distribution
                 this.version.distribution == "opensearch" && this.version.number.startsWith("1.") -> SearchEngineVariant.OS1
-                    this.version.distribution == "opensearch" && this.version.number.startsWith("2.") ->SearchEngineVariant.OS1
+                    this.version.distribution == "opensearch" && this.version.number.startsWith("2.") ->SearchEngineVariant.OS2
                 this.version.number.startsWith("7.") -> SearchEngineVariant.ES7
                 this.version.number.startsWith("8.") -> SearchEngineVariant.ES8
                 else -> error("version not recognized")


### PR DESCRIPTION
I'm no expert on the intricacies of opensearch versioning, but I thought I'd offer this naive-PR in case this was indeed a typo.