### PR TITLE
adds "explanation" field to the Hit

### DIFF
--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/SearchResponse.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/SearchResponse.kt
@@ -47,6 +47,8 @@ data class SearchResponse(
         override val primaryTerm: Int?=null,
         @SerialName("_version")
         override val version: Long?,
+        @SerialName("_explanation")
+        val explanation: JsonObject?,
     ): SourceInformation
 
     @Serializable


### PR DESCRIPTION
search method has "explain" parameter but we cannot
actually use the _explanation field from the
response