### PR TITLE
more useful 4xx exceptions

### DIFF
--- a/docker-compose-es-8.yml
+++ b/docker-compose-es-8.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   es8:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.9.0
     environment:
       - cluster.name=docker-test-cluster
       - bootstrap.memory_lock=true

--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/KtorRestClient.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/KtorRestClient.kt
@@ -19,16 +19,23 @@ expect fun defaultKtorHttpClient(
  * Ktor-client implementation of the RestClient.
  */
 class KtorRestClient(
-    private vararg val nodes: Node = arrayOf(Node(
-        "localhost", 9200
-    )),
+    private vararg val nodes: Node = arrayOf(
+        Node(
+            "localhost", 9200
+        )
+    ),
     private val https: Boolean = false,
     private val user: String? = null,
     private val password: String? = null,
     private val logging: Boolean = false,
     private val nodeSelector: NodeSelector = RoundRobinNodeSelector(nodes),
     private val elasticApiKey: String? = null,
-    private val client: HttpClient = defaultKtorHttpClient(logging = logging, user = user, password = password, elasticApiKey = elasticApiKey),
+    private val client: HttpClient = defaultKtorHttpClient(
+        logging = logging,
+        user = user,
+        password = password,
+        elasticApiKey = elasticApiKey
+    ),
 ) : RestClient, Closeable {
     constructor(
         host: String = "localhost",
@@ -38,7 +45,12 @@ class KtorRestClient(
         password: String? = null,
         logging: Boolean = false,
         elasticApiKey: String? = null,
-        client: HttpClient = defaultKtorHttpClient(logging = logging, user = user, password = password, elasticApiKey = elasticApiKey),
+        client: HttpClient = defaultKtorHttpClient(
+            logging = logging,
+            user = user,
+            password = password,
+            elasticApiKey = elasticApiKey
+        ),
     ) : this(
         client = client,
         https = https,
@@ -121,10 +133,36 @@ class KtorRestClient(
                 responseBody
             )
 
-            HttpStatusCode.BadRequest -> RestResponse.Status4XX.BadRequest(responseBody)
-            HttpStatusCode.Unauthorized -> RestResponse.Status4XX.UnAuthorized(responseBody)
-            HttpStatusCode.Forbidden -> RestResponse.Status4XX.Forbidden(responseBody)
-            HttpStatusCode.NotFound -> RestResponse.Status4XX.NotFound(responseBody)
+            HttpStatusCode.BadRequest -> RestResponse.Status4XX.BadRequest(
+                responseBody,
+                pathComponents.joinToString("/"),
+                payload
+            )
+
+            HttpStatusCode.Unauthorized -> RestResponse.Status4XX.UnAuthorized(
+                responseBody,
+                pathComponents.joinToString("/"),
+                payload
+            )
+
+            HttpStatusCode.Forbidden -> RestResponse.Status4XX.Forbidden(
+                responseBody,
+                pathComponents.joinToString("/"),
+                payload
+            )
+
+            HttpStatusCode.NotFound -> RestResponse.Status4XX.NotFound(
+                responseBody,
+                pathComponents.joinToString("/"),
+                payload
+            )
+
+            HttpStatusCode.TooManyRequests -> RestResponse.Status4XX.TooManyRequests(
+                responseBody,
+                pathComponents.joinToString("/"),
+                payload
+            )
+
             HttpStatusCode.InternalServerError -> RestResponse.Status5xx.InternalServerError(responseBody)
             HttpStatusCode.GatewayTimeout -> RestResponse.Status5xx.GatewayTimeout(responseBody)
             HttpStatusCode.ServiceUnavailable -> RestResponse.Status5xx.ServiceUnavailable(responseBody)

--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/Restclient.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/Restclient.kt
@@ -64,12 +64,34 @@ sealed class RestResponse(open val status: Int) {
             Status3XX(304)
     }
 
-    abstract class Status4XX(override val status: Int, override val responseCategory: ResponseCategory = ResponseCategory.RequestIsWrong) :
+    abstract class Status4XX(override val status: Int, val path: String,requestBody: String?, override val responseCategory: ResponseCategory = ResponseCategory.RequestIsWrong) :
         RestResponse(status) {
-        class BadRequest(override val bytes: ByteArray) : Status4XX(400)
-        class NotFound(override val bytes: ByteArray) : Status4XX(404)
-        class UnAuthorized(override val bytes: ByteArray) : Status4XX(401)
-        class Forbidden(override val bytes: ByteArray) : Status4XX(403)
+        class BadRequest(override val bytes: ByteArray,path: String,  requestBody: String?) : Status4XX(
+            status = 400,
+            path = path,
+            requestBody = requestBody
+        )
+        class NotFound(override val bytes: ByteArray,path: String,  requestBody: String?) : Status4XX(
+            status = 404,
+            path = path,
+            requestBody = requestBody
+        )
+        class UnAuthorized(override val bytes: ByteArray, path: String, requestBody: String?) : Status4XX(
+            status = 401,
+            path = path,
+            requestBody = requestBody
+        )
+        class Forbidden(override val bytes: ByteArray, path: String, requestBody: String?) : Status4XX(
+            status = 403,
+            path = path,
+            requestBody = requestBody
+        )
+        // usually means a circuit breaker kicked in
+        class TooManyRequests(override val bytes: ByteArray, path: String,requestBody: String?) : Status4XX(
+            status = 429,
+            path = path,
+            requestBody = requestBody
+        )
     }
 
     abstract class Status5xx(override val status: Int, override val responseCategory: ResponseCategory = ResponseCategory.ServerProblem) :


### PR DESCRIPTION
- revert back until we can figure out why es is having oom issues suddenly
- 4xx exceptions now include path and request payload for easier diagnostics
