### PR TITLE
add support for highlighting in QueryDSL

### DIFF
--- a/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/highlight-dsl.kt
+++ b/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/highlight-dsl.kt
@@ -1,0 +1,84 @@
+package com.jillesvangurp.searchdsls.querydsl
+
+fun SearchDSL.highlight(block: Highlight.() -> Unit) {
+    val builder = Highlight()
+    block.invoke(builder)
+    this["highlight"] = builder
+}
+
+fun Highlight.field(name: String): Field {
+    return Field(name)
+}
+
+fun Highlight.field(
+    name: String,
+    block: Field.() -> Unit,
+): Field {
+    val hf = Field(name)
+    block.invoke(hf)
+    return hf
+}
+
+@Suppress("EnumEntryName")
+enum class BoundaryScanner {
+    chars,
+    sentence,
+    word,
+}
+
+@Suppress("EnumEntryName")
+enum class Encoder {
+    default,
+    html,
+}
+
+@Suppress("EnumEntryName")
+enum class Fragmenter {
+    simple,
+    span,
+}
+
+@Suppress("EnumEntryName")
+enum class Order {
+    none,
+    score,
+}
+
+@Suppress("EnumEntryName")
+enum class Type {
+    unified,
+    plain,
+    fvh,
+}
+
+open class Field(name: String) : ESQuery(name) {
+    var boundaryChars by queryDetails.property<String>()
+    var boundaryMaxScan by queryDetails.property<Int>()
+    var boundaryScanner by queryDetails.property<BoundaryScanner>()
+    var boundaryScannerLocale by queryDetails.property<String>()
+    var encoder by queryDetails.property<Encoder>()
+    var fragmenter by queryDetails.property(Fragmenter.span)
+    var fragmentOffset by queryDetails.property<Int>()
+    var fragmentSize by queryDetails.property<Int>()
+
+    var highlightQuery by queryDetails.property<ESQuery>()
+
+    var noMatchSize by queryDetails.property<Int>()
+    var numberOfFragments by queryDetails.property<Int>()
+    var order by queryDetails.property<Order>()
+    var phraseLimit by queryDetails.property<Int>()
+    var preTags by queryDetails.property<String>()
+    var postTags by queryDetails.property<String>()
+    var requireFieldMatch by queryDetails.property<Boolean>()
+    var maxAnalyzedOffset by queryDetails.property<Int>()
+    var tagsSchema by queryDetails.property<String>()
+    var type by queryDetails.property<Type>()
+
+    fun matchedFields(vararg matchedFields: String) = queryDetails.getOrCreateMutableList("matched_fields")
+}
+
+class Highlight : Field("highlight") {
+    fun fields(vararg fields: Field) =
+        queryDetails.getOrCreateMutableList("fields")
+            .addAll(fields.map { it.wrapWithName() })
+}


### PR DESCRIPTION
Added support for highlighting in SearchDSL according to https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html

Sample query:
```
{
  query = bool {
      [...]
  }

  highlight {
      boundaryChars = ".,!? \\t\\n"
      boundaryMaxScan = 20
      boundaryScanner = BoundaryScanner.chars
      boundaryScannerLocale = "de-DE"
      encoder = Encoder.default
      fragmenter = Fragmenter.span
      fragmentOffset = 10
      fragmentSize = 5
      highlightQuery =
          bool {
              should(
                  multiMatch(
                      "myQuery",
                      "somefield",
                      "anotherfield",
                  ),
              )
          }
      matchedFields(
          "field1",
          "field2",
      )
      noMatchSize = 2
      numberOfFragments = 3
      order = Order.score
      phraseLimit = 3
      preTags = "<b>"
      postTags = "</b>"
      requireFieldMatch = true
      maxAnalyzedOffset = 2
      tagsSchema = "styled"
      type = Type.unified
      fields(
          field("myField") {
              this.phraseLimit = 5
          },
      )
  }
}
```

It translates to:

```
{
  "query": {
    [...]
  },
  "highlight": {
    "boundary_chars": ".,!? \\t\\n",
    "boundary_max_scan": 20,
    "boundary_scanner": "chars",
    "boundary_scanner_locale": "de-DE",
    "encoder": "default",
    "fragmenter": "span",
    "fragment_offset": "10",
    "fragment_size": 5,
    "highlight_query": {
      "bool": {
        "should": {
          "multi_match": {
            "query": "myQuery",
            "fields": [
              "somefield",
              "anotherfield"
            ]
          }
        }
      }
    },
    "matched_fields": [
      "field1",
      "field2"
    ],
    "no_match_size": 2,
    "number_of_fragments": 3,
    "order": "score",
    "phrase_limit": 3,
    "pre_tags": "<b>",
    "post_tags": "</b>",
    "required_field_match": true,
    "max_analyzed_offset": 2,
    "tags_schema": "styled",
    "type": "unified",
    "fields": {
      "myField": {
        "phrase_limit": 5
      }
    }
}
```