### PR TITLE
Add maven dependencies declaration docs

### DIFF
--- a/docs/src/test/kotlin/documentation/projectreadme/maven.md
+++ b/docs/src/test/kotlin/documentation/projectreadme/maven.md
@@ -1,0 +1,38 @@
+## Maven
+
+If you have maven based kotlin project targeting jvm and can't use kotlin multiplatform dependency, you would need to add jvm targeting artifacts.  
+
+Add the `maven.tryformation.com` repository:
+
+```xml
+<repositories>
+    <repository>
+        <id>try-formation</id>
+        <name>kt search repository</name>
+        <url>https://maven.tryformation.com/releases</url>
+    </repository>
+</repositories>
+```
+
+And then add dependencies to jvm targets:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>com.jillesvangurp</groupId>
+        <artifactId>search-client-jvm</artifactId>
+        <version>2.1.25</version>
+    </dependency>
+    <dependency>
+        <groupId>com.jillesvangurp</groupId>
+        <artifactId>search-dsls-jvm</artifactId>
+        <version>2.1.25</version>
+    </dependency>
+    <dependency>
+        <groupId>com.jillesvangurp</groupId>
+        <artifactId>json-dsl-jvm</artifactId>
+        <version>3.0.0</version>
+    </dependency>
+</dependencies>
+```
+**Note:** The `json-dsl` is moved to separate repository. To find the latest version number, check releases: https://github.com/jillesvangurp/json-dsl/releases

--- a/docs/src/test/kotlin/documentation/projectreadme/readme.kt
+++ b/docs/src/test/kotlin/documentation/projectreadme/readme.kt
@@ -23,6 +23,8 @@ val projectReadme = sourceGitRepository.md {
 
     includeMdFile("gradle.md")
 
+    includeMdFile("maven.md")
+
     section("Usage") {
         // our test server runs on port 9999
         val client = SearchClient(


### PR DESCRIPTION
Gradle allows to include all artefacts from group, but maven doesn't. That means, it's needed to specify all jvm targeting artefacts explicitly as dependencies. Adding this part to documentation, so people who don't know much about kotlin multiplatform internals may find it easier to add dependency into project