### PR TITLE
Add support for script based sorting in SortBuilder

### DIFF
--- a/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/search-dsl.kt
+++ b/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/search-dsl.kt
@@ -154,6 +154,30 @@ class SortBuilder {
             block?.invoke(this)
         }, PropertyNamingConvention.AsIs)
     })
+
+    fun addScript(
+        source: String,
+        type: String,
+        order: SortOrder = SortOrder.DESC,
+        lang: String? = "painless",
+        params: Map<String, Any>? = null,
+        block: (JsonDsl.() -> Unit)? = null
+    ) = _sortFields.add(withJsonDsl {
+        this["_script"] = dslObject {
+            this["order"] = order.name
+            this["type"] = type
+            this["script"] = dslObject {
+                this["source"] = source
+                lang?.let {
+                    this["lang"] = lang
+                }
+                if (params?.isNotEmpty() == true) {
+                    this["params"] = withJsonDsl { params.forEach { (key, value) -> this[key] = value } }
+                }
+            }
+            block?.invoke(this)
+        }
+    })
 }
 
 fun SearchDSL.sort(block: SortBuilder.() -> Unit) {


### PR DESCRIPTION
Implements #130

This PR introduces support for script-based sorting in SortBuilder, in addition to the existing field name-based sorting functionality.

With this change, you can now sort documents using custom scripts. 

For example:

```kotlin
SearchDSL().apply {
    sort {
        addScript(
            order = SortOrder.ASC,
            type = "number",
            source = "doc['field_name'].value * params.factor;",
            lang = "painless",
            params = mapOf("factor" to 1.1),
        )
        add(
            field = "field_name",
            order = SortOrder.DESC,
            mode = SortMode.AVG,
        )
    }
}

```