### PR TITLE
fixes highlightQuery in the highlight dsl

### DIFF
--- a/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/highlight-dsl.kt
+++ b/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/highlight-dsl.kt
@@ -61,7 +61,7 @@ open class Field(name: String) : ESQuery(name) {
     var fragmentOffset by queryDetails.property<Int>()
     var fragmentSize by queryDetails.property<Int>()
 
-    var highlightQuery by queryDetails.property<ESQuery>()
+    var highlightQuery by queryDetails.esQueryProperty()
 
     var noMatchSize by queryDetails.property<Int>()
     var numberOfFragments by queryDetails.property<Int>()

--- a/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/search-dsl.kt
+++ b/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/search-dsl.kt
@@ -26,13 +26,15 @@ open class ESQuery(
 fun JsonDsl.esQueryProperty(): ReadWriteProperty<Any, ESQuery> {
     return object : ReadWriteProperty<Any, ESQuery> {
         override fun getValue(thisRef: Any, property: KProperty<*>): ESQuery {
-            val map = this@esQueryProperty[property.name] as Map<String, JsonDsl>
+            val propertyName = property.name.convertPropertyName(defaultNamingConvention)
+            val map = this@esQueryProperty[propertyName] as Map<String, JsonDsl>
             val (name, queryDetails) = map.entries.first()
             return ESQuery(name, queryDetails)
         }
 
         override fun setValue(thisRef: Any, property: KProperty<*>, value: ESQuery) {
-            this@esQueryProperty[property.name] = value.wrapWithName()
+            val propertyName = property.name.convertPropertyName(defaultNamingConvention)
+            this@esQueryProperty[propertyName] = value.wrapWithName()
         }
     }
 }


### PR DESCRIPTION
Without esQueryProperty dsl does not call wrapWithName() automatically and query is not applied correctly.

Also, esQueryProperty does not apply field naming policy and for other one-word fields it does not change anything but for highlightQuery we have to apply it as highlight_query