### PR TITLE
adds key_as_string for boolean aggregation result.

### DIFF
--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/SearchResponse.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/SearchResponse.kt
@@ -157,6 +157,8 @@ data class TermsBucket(
     val key: String,
     @SerialName("doc_count")
     val docCount: Long,
+    @SerialName("key_as_string")
+    val keyAsString: String?,
 )
 
 @Serializable


### PR DESCRIPTION
From "Boolean field type" docs:
Aggregations like the terms aggregation use 1 and 0 for the key, and the strings "true" and "false" for the key_as_string.

https://www.elastic.co/guide/en/elasticsearch/reference/current/boolean.html

Sorry for many PRs at once 🙏 we recently started to use the library actively and have found out few parts which can be improved.
