### PR TITLE
upgrade to ktor-client 3.0 & adds wasm

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Compose up
       run: ./gradlew :search-client:composeUp
     - name: Gradle Build
-      run: ./gradlew check -x jsTest -x jsBrowserTest -x jsNodeTest
+      # skipping js/wasm targets because of browser related flakiness and random client failures
+      run: ./gradlew check -x jsTest -x jsBrowserTest -x jsNodeTest -x wasmJsBrowserTest -x wasmJsNodeTest -x wasmJsD8Test
     - name: Compose down
       run: ./gradlew :search-client:composeDown

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -56,8 +56,6 @@ dependencies {
     testImplementation("io.ktor:ktor-client-content-negotiation:_")
 
 
-    testImplementation("io.github.microutils:kotlin-logging:_")
-
     // bring your own logging, but we need some in tests
     testImplementation("org.slf4j:slf4j-api:_")
     testImplementation("org.slf4j:jcl-over-slf4j:_")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -281,10 +281,10 @@ accepts@~1.3.4:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
-  integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
 
 acorn@^8.7.1, acorn@^8.8.2:
   version "8.10.0"
@@ -306,10 +306,10 @@ ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-colors@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+ansi-colors@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -391,7 +391,7 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browser-stdout@1.3.1:
+browser-stdout@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
@@ -442,10 +442,25 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@3.5.3, chokidar@^3.5.1:
+chokidar@^3.5.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+chokidar@^3.5.3:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -566,12 +581,19 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.4, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
+debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^4.3.5:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
+  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize@^4.0.0:
   version "4.0.0"
@@ -593,10 +615,10 @@ di@^0.0.1:
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==
 
-diff@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+diff@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
+  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 dom-serialize@^2.2.1:
   version "2.2.1"
@@ -649,10 +671,10 @@ engine.io@~6.5.2:
     engine.io-parser "~5.2.1"
     ws "~8.11.0"
 
-enhanced-resolve@^5.16.0:
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz#e8bc63d51b826d6f1cbc0a150ecb5a8b0c62e567"
-  integrity sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==
+enhanced-resolve@^5.17.0:
+  version "5.17.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz#67bfbbcc2f81d511be77d686a90267ef7f898a15"
+  integrity sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -682,7 +704,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@4.0.0:
+escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
@@ -767,20 +789,20 @@ finalhandler@1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-up@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
 find-up@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 flat@^5.0.2:
@@ -854,17 +876,6 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
-  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-
 glob@^7.1.3, glob@^7.1.7:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -876,6 +887,17 @@ glob@^7.1.3, glob@^7.1.7:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
@@ -902,7 +924,7 @@ has@^1.0.3:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
   integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
 
-he@1.2.0:
+he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -1044,7 +1066,7 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-js-yaml@4.1.0:
+js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -1157,7 +1179,7 @@ lodash@^4.17.15, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@4.1.0:
+log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -1203,13 +1225,6 @@ mime@^2.5.2:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
-minimatch@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -1217,7 +1232,7 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
+minimatch@^5.0.1, minimatch@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -1243,31 +1258,31 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
-  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
+mocha@10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.0.tgz#9e5cbed8fa9b37537a25bd1f7fb4f6fc45458b9a"
+  integrity sha512-v8/rBWr2VO5YkspYINnvu81inSz2y3ODJrhO175/Exzor1RcEZZkizgE2A+w/CAXXoESS8Kys5E62dOHGHzULA==
   dependencies:
-    ansi-colors "4.1.1"
-    browser-stdout "1.3.1"
-    chokidar "3.5.3"
-    debug "4.3.4"
-    diff "5.0.0"
-    escape-string-regexp "4.0.0"
-    find-up "5.0.0"
-    glob "8.1.0"
-    he "1.2.0"
-    js-yaml "4.1.0"
-    log-symbols "4.1.0"
-    minimatch "5.0.1"
-    ms "2.1.3"
-    serialize-javascript "6.0.0"
-    strip-json-comments "3.1.1"
-    supports-color "8.1.1"
-    workerpool "6.2.1"
-    yargs "16.2.0"
-    yargs-parser "20.2.4"
-    yargs-unparser "2.0.0"
+    ansi-colors "^4.1.3"
+    browser-stdout "^1.3.1"
+    chokidar "^3.5.3"
+    debug "^4.3.5"
+    diff "^5.2.0"
+    escape-string-regexp "^4.0.0"
+    find-up "^5.0.0"
+    glob "^8.1.0"
+    he "^1.2.0"
+    js-yaml "^4.1.0"
+    log-symbols "^4.1.0"
+    minimatch "^5.1.6"
+    ms "^2.1.3"
+    serialize-javascript "^6.0.2"
+    strip-json-comments "^3.1.1"
+    supports-color "^8.1.1"
+    workerpool "^6.5.1"
+    yargs "^16.2.0"
+    yargs-parser "^20.2.9"
+    yargs-unparser "^2.0.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1279,7 +1294,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -1532,17 +1547,17 @@ schema-utils@^3.1.1, schema-utils@^3.2.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-serialize-javascript@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
-  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
-  dependencies:
-    randombytes "^2.1.0"
-
 serialize-javascript@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
   integrity sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
 
@@ -1668,22 +1683,22 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-json-comments@3.1.1:
+strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-supports-color@8.1.1, supports-color@^8.0.0:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
 
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.0.0, supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -1750,10 +1765,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@5.4.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
-  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 ua-parser-js@^0.7.30:
   version "0.7.36"
@@ -1858,10 +1873,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.91.0:
-  version "5.91.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.91.0.tgz#ffa92c1c618d18c878f06892bbdc3373c71a01d9"
-  integrity sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==
+webpack@5.93.0:
+  version "5.93.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.93.0.tgz#2e89ec7035579bdfba9760d26c63ac5c3462a5e5"
+  integrity sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.5"
@@ -1869,10 +1884,10 @@ webpack@5.91.0:
     "@webassemblyjs/wasm-edit" "^1.12.1"
     "@webassemblyjs/wasm-parser" "^1.12.1"
     acorn "^8.7.1"
-    acorn-import-assertions "^1.9.0"
+    acorn-import-attributes "^1.9.5"
     browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.16.0"
+    enhanced-resolve "^5.17.0"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -1915,10 +1930,10 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
-workerpool@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
-  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
+workerpool@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
+  integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -1949,17 +1964,12 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yargs-parser@20.2.4:
-  version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
-yargs-parser@^20.2.2:
+yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-unparser@2.0.0:
+yargs-unparser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
   integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
@@ -1969,7 +1979,7 @@ yargs-unparser@2.0.0:
     flat "^5.0.2"
     is-plain-obj "^2.1.0"
 
-yargs@16.2.0, yargs@^16.1.1:
+yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==

--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/repository/IndexRepository.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/repository/IndexRepository.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.serialization.KSerializer
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes

--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/search-api.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/search-api.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds

--- a/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/BulkTest.kt
+++ b/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/BulkTest.kt
@@ -10,110 +10,122 @@ class BulkTest : SearchTestBase() {
 
     @Test
     fun shouldBulkIndex() = coRun {
-        val index = testDocumentIndex()
+        testDocumentIndex { index ->
 
-        client.bulk(refresh = Refresh.WaitFor, bulkSize = 4, target = index) {
-            (1..20).forEach {
-                create(TestDocument(name = "doc $it").json(false))
+
+            client.bulk(refresh = Refresh.WaitFor, bulkSize = 4, target = index) {
+                (1..20).forEach {
+                    create(TestDocument(name = "doc $it").json(false))
+                }
             }
-        }
-        client.search(index) {
+            client.search(index) {
 
-        }.total shouldBe 20
+            }.total shouldBe 20
+        }
     }
 
     @Test
     fun shouldCallback() = coRun {
-        val index = testDocumentIndex()
-        var success = 0
-        var failed = 0
-        client.bulk(target = index, bulkSize = 4, callBack = object : BulkItemCallBack {
-            override fun itemFailed(operationType: OperationType, item: BulkResponse.ItemDetails) {
-                failed++
+        testDocumentIndex { index ->
+
+            var success = 0
+            var failed = 0
+            client.bulk(target = index, bulkSize = 4, callBack = object : BulkItemCallBack {
+                override fun itemFailed(operationType: OperationType, item: BulkResponse.ItemDetails) {
+                    failed++
+                }
+
+                override fun itemOk(operationType: OperationType, item: BulkResponse.ItemDetails) {
+                    success++
+                }
+
+                override fun bulkRequestFailed(e: Exception, ops: List<Pair<String, String?>>) {
+                    error("${e.message} on")
+                }
+            }) {
+                (1..10).forEach {
+                    index(TestDocument(name = "doc $it").json())
+                }
             }
 
-            override fun itemOk(operationType: OperationType, item: BulkResponse.ItemDetails) {
-                success++
-            }
-
-            override fun bulkRequestFailed(e: Exception, ops: List<Pair<String, String?>>) {
-                error("${e.message} on")
-            }
-        }) {
-            (1..10).forEach {
-                index(TestDocument(name = "doc $it").json())
-            }
+            success shouldBe 10
+            failed shouldBe 0
         }
-
-        success shouldBe 10
-        failed shouldBe 0
     }
 
     @Test
     fun shouldHandleSourceFieldOnUpdate() = coRun {
-        val index = testDocumentIndex()
-        client.bulk(target = index, source="true") {
-            update(TestDocument("bar"), id="1", docAsUpsert = true)
+        testDocumentIndex { index ->
+            client.bulk(target = index, source = "true") {
+                update(TestDocument("bar"), id = "1", docAsUpsert = true)
+            }
         }
     }
 
     @Test
     fun shouldHandleScriptUpdate() = coRun {
-        val index = testDocumentIndex()
-        client.bulk(target = index, source="true") {
-            // will get initialized to 0 by the upsert
-            update(script = Script.create {
-                source="ctx._source.number += params.param1"
-                params= mapOf(
-                    "param1" to 10
-                )
-            }, id = "1", upsert = TestDocument("counter", number = 0))
-            // now the script runs
-            update(script = Script.create {
-                source="ctx._source.number += params.param1"
-                params= mapOf(
-                    "param1" to 10
-                )
-            }, id = "1", upsert = TestDocument("counter", number = 0))
+        testDocumentIndex { index ->
+            client.bulk(target = index, source = "true") {
+                // will get initialized to 0 by the upsert
+                update(script = Script.create {
+                    source = "ctx._source.number += params.param1"
+                    params = mapOf(
+                        "param1" to 10
+                    )
+                }, id = "1", upsert = TestDocument("counter", number = 0))
+                // now the script runs
+                update(script = Script.create {
+                    source = "ctx._source.number += params.param1"
+                    params = mapOf(
+                        "param1" to 10
+                    )
+                }, id = "1", upsert = TestDocument("counter", number = 0))
+            }
         }
     }
 
     @Test
     fun shouldAcceptSerializedUpdate() = coRun {
-        val index = testDocumentIndex()
-        client.bulk(target = index, source="true") {
-            // will get initialized to 0 by the upsert
+        testDocumentIndex { index ->
+            client.bulk(target = index, source = "true") {
+                // will get initialized to 0 by the upsert
 
-            create(TestDocument("original"), id = "42")
-            // now the script runs
-            update(TestDocument("changed"), id = "42")
+                create(TestDocument("original"), id = "42")
+                // now the script runs
+                update(TestDocument("changed"), id = "42")
+            }
+            val resp = client.getDocument(index, "42").source!!.parse<TestDocument>()
+            resp.name shouldBe "changed"
         }
-        val resp = client.getDocument(index,"42").source!!.parse<TestDocument>()
-        resp.name shouldBe "changed"
     }
 
     @Test
     fun shouldOverrideBulkRoutingForItemsWithRouting() = coRun {
-        val index = testDocumentIndex()
-        client.bulk(target = index, source="true", routing = "1") {
-            create(doc = TestDocument(name = "document with specific routing"), id = "42", routing = "2")
-            create(doc = TestDocument(name = "document without specific routing"), id = "43")
-            index(doc = TestDocument(name = "document to delete"), id = "44", routing = "3")
+        testDocumentIndex { index ->
+            client.bulk(target = index, source = "true", routing = "1") {
+                create(doc = TestDocument(name = "document with specific routing"), id = "42", routing = "2")
+                create(doc = TestDocument(name = "document without specific routing"), id = "43")
+                index(doc = TestDocument(name = "document to delete"), id = "44", routing = "3")
 
-            update(id = "42", doc = TestDocument(name = "document with specific routing updated").json(), routing = "2")
+                update(
+                    id = "42",
+                    doc = TestDocument(name = "document with specific routing updated").json(),
+                    routing = "2"
+                )
 
-            delete(id = "44", routing = "3")
+                delete(id = "44", routing = "3")
+            }
+
+            val docWithSpecificRouting = client.getDocument(index, "42")
+            val docWithoutSpecificRouting = client.getDocument(index, "43")
+
+            shouldThrow<RestException> {
+                client.getDocument(index, "44")
+            }.message shouldContain "RequestIsWrong 404"
+
+            docWithSpecificRouting.routing shouldBe "2"
+            docWithSpecificRouting.source!!.parse<TestDocument>().name shouldBe "document with specific routing updated"
+            docWithoutSpecificRouting.routing shouldBe "1"
         }
-
-        val docWithSpecificRouting = client.getDocument(index, "42")
-        val docWithoutSpecificRouting = client.getDocument(index, "43")
-
-        shouldThrow<RestException> {
-            client.getDocument(index, "44")
-        }.message shouldContain "RequestIsWrong 404"
-
-        docWithSpecificRouting.routing shouldBe "2"
-        docWithSpecificRouting.source!!.parse<TestDocument>().name shouldBe "document with specific routing updated"
-        docWithoutSpecificRouting.routing shouldBe "1"
     }
 }

--- a/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/DeleteByQyeryTest.kt
+++ b/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/DeleteByQyeryTest.kt
@@ -8,14 +8,16 @@ class DeleteByQyeryTest: SearchTestBase() {
 
     @Test
     fun shouldDeleteByQuery() = coRun {
-        val index = testDocumentIndex()
-        client.indexDocument(index, TestDocument("foo bar").json(false), refresh = Refresh.WaitFor)
-        client.indexDocument(index, TestDocument("fooo").json(false), refresh = Refresh.WaitFor)
+        testDocumentIndex { index ->
 
-        val resp = client.deleteByQuery(index) {
-            query = matchAll()
+            client.indexDocument(index, TestDocument("foo bar").json(false), refresh = Refresh.WaitFor)
+            client.indexDocument(index, TestDocument("fooo").json(false), refresh = Refresh.WaitFor)
+
+            val resp = client.deleteByQuery(index) {
+                query = matchAll()
+            }
+
+            resp.deleted shouldBe 2
         }
-
-        resp.deleted shouldBe 2
     }
 }

--- a/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/DocumentCRUDTest.kt
+++ b/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/DocumentCRUDTest.kt
@@ -11,100 +11,109 @@ class DocumentCRUDTest: SearchTestBase() {
 
     @Test
     fun shouldDoDocumentCrud() = coRun {
-        val index = testDocumentIndex()
-        client.indexDocument(index, TestDocument("xx").json(false)).also { createResponse ->
-            createResponse.index shouldBe index
-            createResponse.shards.failed shouldBe 0
-            client.getDocument(index, createResponse.id).also { getResponse ->
-                val document = getResponse.document<TestDocument>()
-                getResponse.id shouldBe createResponse.id
-                document.name shouldBe "xx"
-                client.indexDocument(index,TestDocument(name = "yy").json(false), id = getResponse.id).also { updateResponse ->
-                    updateResponse.id shouldBe createResponse.id
+        testDocumentIndex { index ->
 
+            client.indexDocument(index, TestDocument("xx").json(false)).also { createResponse ->
+                createResponse.index shouldBe index
+                createResponse.shards.failed shouldBe 0
+                client.getDocument(index, createResponse.id).also { getResponse ->
+                    val document = getResponse.document<TestDocument>()
+                    getResponse.id shouldBe createResponse.id
+                    document.name shouldBe "xx"
+                    client.indexDocument(index, TestDocument(name = "yy").json(false), id = getResponse.id)
+                        .also { updateResponse ->
+                            updateResponse.id shouldBe createResponse.id
+
+                        }
                 }
-            }
-            client.getDocument(index, createResponse.id).also { getResponse ->
-                val document = getResponse.document<TestDocument>()
-                document.name shouldBe "yy"
-            }
-            client.deleteDocument(index,createResponse.id)
-            try {
-                client.getDocument(index, createResponse.id)
-                fail("should throw")
-            } catch (e: RestException) {
-                // not a problem
+                client.getDocument(index, createResponse.id).also { getResponse ->
+                    val document = getResponse.document<TestDocument>()
+                    document.name shouldBe "yy"
+                }
+                client.deleteDocument(index, createResponse.id)
+                try {
+                    client.getDocument(index, createResponse.id)
+                    fail("should throw")
+                } catch (e: RestException) {
+                    // not a problem
+                }
             }
         }
     }
 
     @Test
     fun shouldSupportDocumentUpdates() = coRun {
-        val index = testDocumentIndex()
-        client.indexDocument(index,TestDocument("foo", id=1),"1")
+        testDocumentIndex { index ->
 
-        client.updateDocument(index,"1", TestDocument("bar",id=1)).let { resp ->
-            resp.result shouldBe "updated"
-        }
-        client.updateDocument(index,"1", TestDocument("bar",id=1), detectNoop = true).let { resp ->
-            resp.result shouldBe "noop"
+            client.indexDocument(index, TestDocument("foo", id = 1), "1")
+
+            client.updateDocument(index, "1", TestDocument("bar", id = 1)).let { resp ->
+                resp.result shouldBe "updated"
+            }
+            client.updateDocument(index, "1", TestDocument("bar", id = 1), detectNoop = true).let { resp ->
+                resp.result shouldBe "noop"
+            }
         }
     }
 
     @Test
     fun shouldSupportScriptUpdates() = coRun {
-        val index = testDocumentIndex()
-        client.updateDocument(
-            target = index,
-            id = "1",
-            script = Script.create {
-                source = "ctx._source.number += params.param1"
-                params = mapOf(
-                    "param1" to 1
-                )
-            },
-            upsertJson = TestDocument("foo", number = 0),
-        )
-        client.updateDocument(
-            target = index,
-            id = "1",
-            script = Script.create {
-                source = "ctx._source.number += params.param1"
-                params = mapOf(
-                    "param1" to 1
-                )
-            },
-            upsertJson = TestDocument("foo", number = 0),
-            source = "true"
-        ).let { resp ->
-            resp.get?.source shouldNotBe null
-            DEFAULT_JSON.decodeFromJsonElement(TestDocument.serializer(),resp.get?.source!!).let {
-                it.number shouldBe 1
+        testDocumentIndex { index ->
+
+            client.updateDocument(
+                target = index,
+                id = "1",
+                script = Script.create {
+                    source = "ctx._source.number += params.param1"
+                    params = mapOf(
+                        "param1" to 1
+                    )
+                },
+                upsertJson = TestDocument("foo", number = 0),
+            )
+            client.updateDocument(
+                target = index,
+                id = "1",
+                script = Script.create {
+                    source = "ctx._source.number += params.param1"
+                    params = mapOf(
+                        "param1" to 1
+                    )
+                },
+                upsertJson = TestDocument("foo", number = 0),
+                source = "true"
+            ).let { resp ->
+                resp.get?.source shouldNotBe null
+                DEFAULT_JSON.decodeFromJsonElement(TestDocument.serializer(), resp.get?.source!!).let {
+                    it.number shouldBe 1
+                }
             }
         }
     }
 
     @Test
     fun shouldMgetDocs() = coRun {
-        val indexName = testDocumentIndex()
-        client.indexDocument(indexName, TestDocument("foo", description = "Foo"), id = "1")
-        client.indexDocument(indexName, TestDocument("bar",description = "Bar"), id = "2")
+        testDocumentIndex { indexName ->
 
-        client.mGet {
-            doc {
-                id="1"
-                index=indexName
-                source=true
-            }
-            doc {
-                id="idontexist"
-                index=indexName
-                source=true
-            }
+            client.indexDocument(indexName, TestDocument("foo", description = "Foo"), id = "1")
+            client.indexDocument(indexName, TestDocument("bar", description = "Bar"), id = "2")
 
-        }.docs.let {
-            it.firstOrNull { !it.found } shouldNotBe null
-            it.size shouldBe 2
+            client.mGet {
+                doc {
+                    id = "1"
+                    index = indexName
+                    source = true
+                }
+                doc {
+                    id = "idontexist"
+                    index = indexName
+                    source = true
+                }
+
+            }.docs.let {
+                it.firstOrNull { !it.found } shouldNotBe null
+                it.size shouldBe 2
+            }
         }
     }
 }

--- a/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/GeoSpatialQueriesTest.kt
+++ b/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/GeoSpatialQueriesTest.kt
@@ -9,32 +9,33 @@ class GeoSpatialQueriesTest : SearchTestBase() {
 
     @Test
     fun shouldDoBoundingBox() = coRun {
-        val index = geoTestFixture()
-        client.search(index) {
-            query = GeoBoundingBoxQuery(TestDocument::point) {
-                topLeft(arrayOf(12.0, 53.0))
-                bottomRight(arrayOf(14.0, 51.0))
-            }
-        }.total shouldBe 1
+        geoTestFixture { index ->
+            client.search(index) {
+                query = GeoBoundingBoxQuery(TestDocument::point) {
+                    topLeft(arrayOf(12.0, 53.0))
+                    bottomRight(arrayOf(14.0, 51.0))
+                }
+            }.total shouldBe 1
 
-        client.search(index) {
-            query = GeoBoundingBoxQuery(TestDocument::point) {
-                topLeft(arrayOf(14.0, 53.0))
-                bottomRight(arrayOf(16.0, 51.0))
-            }
-        }.total shouldBe 0
-
+            client.search(index) {
+                query = GeoBoundingBoxQuery(TestDocument::point) {
+                    topLeft(arrayOf(14.0, 53.0))
+                    bottomRight(arrayOf(16.0, 51.0))
+                }
+            }.total shouldBe 0
+        }
     }
 
     @Test
     fun shouldDoDistanceSearch() = coRun {
-        val index = geoTestFixture()
-        client.search(index) {
-            query = GeoDistanceQuery(TestDocument::point, "1000km", "POINT (13.0 51.0)")
-        }.total shouldBe 1
-        client.search(index) {
-            query = GeoDistanceQuery(TestDocument::point, "1km", "POINT (13.0 51.0)")
-        }.total shouldBe 0
+        geoTestFixture { index ->
+            client.search(index) {
+                query = GeoDistanceQuery(TestDocument::point, "1000km", "POINT (13.0 51.0)")
+            }.total shouldBe 1
+            client.search(index) {
+                query = GeoDistanceQuery(TestDocument::point, "1km", "POINT (13.0 51.0)")
+            }.total shouldBe 0
+        }
     }
 
     @Test
@@ -43,47 +44,50 @@ class GeoSpatialQueriesTest : SearchTestBase() {
             "elasticsearch only feature that was introduced in recent 8.x releases",
             SearchEngineVariant.ES8
         ) {
-            val index = geoTestFixture()
-            client.search(index) {
-                query = GeoGridQuery(TestDocument::point) {
-                    geohash = "u33d"
-                }
-            }.total shouldBe 1
-            client.search(index) {
-                query = GeoGridQuery(TestDocument::point) {
-                    geohash = "sr3n"
-                }
-            }.total shouldBe 0
+            geoTestFixture { index ->
+                client.search(index) {
+                    query = GeoGridQuery(TestDocument::point) {
+                        geohash = "u33d"
+                    }
+                }.total shouldBe 1
+                client.search(index) {
+                    query = GeoGridQuery(TestDocument::point) {
+                        geohash = "sr3n"
+                    }
+                }.total shouldBe 0
+            }
         }
     }
 
     @Test
     fun shouldDoGeoShapeQuery() = coRun {
-        val index = geoTestFixture()
-        client.search(index) {
-            query = GeoShapeQuery(TestDocument::point) {
-                shape = Shape.Envelope(listOf(listOf(12.0,53.0), listOf(14.0,51.0)))
-            }
-        }.total shouldBe 1
+        geoTestFixture { index ->
+            client.search(index) {
+                query = GeoShapeQuery(TestDocument::point) {
+                    shape = Shape.Envelope(listOf(listOf(12.0, 53.0), listOf(14.0, 51.0)))
+                }
+            }.total shouldBe 1
 
-        client.search(index) {
-            query = GeoShapeQuery(TestDocument::point) {
-                shape = Shape.Envelope(listOf(listOf(2.0,53.0), listOf(4.0,51.0)))
-            }
-        }.total shouldBe 0
-
+            client.search(index) {
+                query = GeoShapeQuery(TestDocument::point) {
+                    shape = Shape.Envelope(listOf(listOf(2.0, 53.0), listOf(4.0, 51.0)))
+                }
+            }.total shouldBe 0
+        }
     }
 
-    private suspend fun geoTestFixture(): String {
-        val index = testDocumentIndex()
-        client.bulk(target = index, refresh = Refresh.WaitFor) {
-            // Fun fact, I contributed documentation
-            // to Elasticsearch 1.x for geojson based searches back in 2013. The POI
-            // used here refers to a coffee bar / vegan restaurant / and cocktail bar
-            // that no longer exist that we used as our office while writing that documentation.
-            // Somehow, the modern day Elastic documentation still uses this point. ;-)
-            create(TestDocument("Wind und Wetter, Berlin, Germany", point = listOf(13.400544, 52.530286)))
+    suspend fun geoTestFixture(block: suspend (String)->Unit) {
+        testDocumentIndex { index ->
+
+            client.bulk(target = index, refresh = Refresh.WaitFor) {
+                // Fun fact, I contributed documentation
+                // to Elasticsearch 1.x for geojson based searches back in 2013. The POI
+                // used here refers to a coffee bar / vegan restaurant / and cocktail bar
+                // that no longer exist that we used as our office while writing that documentation.
+                // Somehow, the modern day Elastic documentation still uses this point. ;-)
+                create(TestDocument("Wind und Wetter, Berlin, Germany", point = listOf(13.400544, 52.530286)))
+            }
+            block.invoke(index)
         }
-        return index
     }
 }

--- a/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/SearchTestBase.kt
+++ b/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/SearchTestBase.kt
@@ -3,7 +3,7 @@ package com.jillesvangurp.ktsearch
 import com.jillesvangurp.ktsearch.repository.repository
 import com.jillesvangurp.searchdsls.SearchEngineVariant
 import kotlinx.coroutines.test.TestResult
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.time.Duration
@@ -14,6 +14,7 @@ import kotlin.time.Duration.Companion.seconds
 
 expect fun coRun(timeout: Duration = 30.seconds, block: suspend () -> Unit): TestResult
 
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 expect annotation class IgnoreJs()
 
@@ -44,11 +45,13 @@ open class SearchTestBase {
 
     fun randomIndexName() = "index-${Random.nextULong()}"
 
-    suspend fun testDocumentIndex(): String {
+    suspend fun testDocumentIndex(block: suspend (String) -> Unit) {
         val index = randomIndexName()
-        return TestDocument.mapping.let {
+        TestDocument.mapping.let {
             client.createIndex(index,it)
         }.index
+        block.invoke(index)
+        client.deleteIndex(index)
     }
 
     val repo by lazy {

--- a/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/SpecializedQueriesTest.kt
+++ b/search-client/src/commonTest/kotlin/com/jillesvangurp/ktsearch/SpecializedQueriesTest.kt
@@ -12,73 +12,77 @@ class SpecializedQueriesTest : SearchTestBase() {
 
     @Test
     fun shouldRankOnDistance() = coRun {
-        val index = testDocumentIndex()
-        client.bulk(target = index, refresh = Refresh.WaitFor) {
-            create(
-                TestDocument(
-                    name = "p1",
-                    point = listOf(12.0, 50.0),
-                    timestamp = Clock.System.now().minus(10.days)
-                )
-            )
-            create(
-                TestDocument(
-                    name = "p2",
-                    point = listOf(13.0, 52.0),
-                    timestamp = Clock.System.now().minus(5.days)
-                )
-            )
-        }
+        testDocumentIndex { index ->
 
-        client.search(target = index) {
-            query = distanceFeature(TestDocument::timestamp, "30d", "now-40d")
-        }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p1"
-        client.search(target = index) {
-            query = distanceFeature(TestDocument::point, "10km", listOf(14.0, 52.0))
-        }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
+            client.bulk(target = index, refresh = Refresh.WaitFor) {
+                create(
+                    TestDocument(
+                        name = "p1",
+                        point = listOf(12.0, 50.0),
+                        timestamp = Clock.System.now().minus(10.days)
+                    )
+                )
+                create(
+                    TestDocument(
+                        name = "p2",
+                        point = listOf(13.0, 52.0),
+                        timestamp = Clock.System.now().minus(5.days)
+                    )
+                )
+            }
+
+            client.search(target = index) {
+                query = distanceFeature(TestDocument::timestamp, "30d", "now-40d")
+            }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p1"
+            client.search(target = index) {
+                query = distanceFeature(TestDocument::point, "10km", listOf(14.0, 52.0))
+            }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
+        }
     }
 
     @Test
     fun shouldRankFeature() = coRun {
-        val index = testDocumentIndex()
-        client.bulk(target = index, refresh = Refresh.WaitFor) {
-            create(
-                TestDocument(
-                    name = "p1",
-                    feature = 20
+        testDocumentIndex { index ->
+
+            client.bulk(target = index, refresh = Refresh.WaitFor) {
+                create(
+                    TestDocument(
+                        name = "p1",
+                        feature = 20
+                    )
                 )
-            )
-            create(
-                TestDocument(
-                    name = "p2",
-                    feature = 100
+                create(
+                    TestDocument(
+                        name = "p2",
+                        feature = 100
+                    )
                 )
-            )
+            }
+
+            client.search(target = index) {
+                query = rankFeature(TestDocument::feature)
+            }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
+            client.search(target = index) {
+                query = rankFeature(TestDocument::feature) {
+                    linear()
+                }
+            }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
+            client.search(target = index) {
+                query = rankFeature(TestDocument::feature) {
+                    saturation(pivot = 2.0)
+                }
+            }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
+            client.search(target = index) {
+                query = rankFeature(TestDocument::feature) {
+                    log(2.0)
+                }
+            }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
+            client.search(target = index) {
+                query = rankFeature(TestDocument::feature) {
+                    sigmoid(pivot = 2.0, exponent = 0.8)
+                }
+            }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
+
         }
-
-        client.search(target = index) {
-            query = rankFeature(TestDocument::feature)
-        }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
-        client.search(target = index) {
-            query = rankFeature(TestDocument::feature) {
-                linear()
-            }
-        }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
-        client.search(target = index) {
-            query = rankFeature(TestDocument::feature) {
-                saturation(pivot = 2.0)
-            }
-        }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
-        client.search(target = index) {
-            query = rankFeature(TestDocument::feature) {
-                log(2.0)
-            }
-        }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
-        client.search(target = index) {
-            query = rankFeature(TestDocument::feature) {
-                sigmoid(pivot=2.0,exponent = 0.8)
-            }
-        }.hits?.hits?.first()?.parseHit<TestDocument>()!!.name shouldBe "p2"
-
     }
 }

--- a/search-client/src/wasmJsMain/kotlin/com/jillesvangurp/ktsearch/KtorRestClient.wasmJs.kt
+++ b/search-client/src/wasmJsMain/kotlin/com/jillesvangurp/ktsearch/KtorRestClient.wasmJs.kt
@@ -1,0 +1,12 @@
+package com.jillesvangurp.ktsearch
+
+import io.ktor.client.HttpClient
+
+actual fun defaultKtorHttpClient(
+    logging: Boolean,
+    user: String?,
+    password: String?,
+    elasticApiKey: String?
+): HttpClient {
+    return HttpClient()
+}

--- a/search-client/src/wasmJsMain/kotlin/com/jillesvangurp/ktsearch/RoundRobinNodeSelector.wasmJs.kt
+++ b/search-client/src/wasmJsMain/kotlin/com/jillesvangurp/ktsearch/RoundRobinNodeSelector.wasmJs.kt
@@ -1,0 +1,11 @@
+package com.jillesvangurp.ktsearch
+
+actual fun simpleIndexProvider(initialIndex: Int): IndexProvider = object : IndexProvider {
+    private var index = 0
+
+    override fun get(): Int = index
+
+    override fun set(value: Int) {
+        index = value
+    }
+}

--- a/search-client/src/wasmJsMain/kotlin/com/jillesvangurp/ktsearch/SniffingNodeSelector.wasmJs.kt
+++ b/search-client/src/wasmJsMain/kotlin/com/jillesvangurp/ktsearch/SniffingNodeSelector.wasmJs.kt
@@ -1,0 +1,8 @@
+package com.jillesvangurp.ktsearch
+
+/**
+ * On JVM this will return the current thread name,  on kotlin-js this will return null
+ */
+actual fun threadId(): String? {
+    return null
+}

--- a/search-client/src/wasmJsTest/kotlin/com/jillesvangurp/ktsearch/SearchTestBase.wasmJs.kt
+++ b/search-client/src/wasmJsTest/kotlin/com/jillesvangurp/ktsearch/SearchTestBase.wasmJs.kt
@@ -1,0 +1,4 @@
+package com.jillesvangurp.ktsearch
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+actual annotation class IgnoreJs actual constructor()

--- a/search-client/src/wasmJsTest/kotlin/com/jillesvangurp/ktsearch/coTest.kt
+++ b/search-client/src/wasmJsTest/kotlin/com/jillesvangurp/ktsearch/coTest.kt
@@ -1,0 +1,19 @@
+package com.jillesvangurp.ktsearch
+
+import kotlin.time.Duration
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.asPromise
+import kotlinx.coroutines.async
+
+@OptIn(DelicateCoroutinesApi::class)
+actual fun coRun(timeout: Duration, block: suspend () -> Unit) = GlobalScope.async {
+    try {
+        block.invoke()
+    } catch (e: Exception) {
+        println("${e::class.simpleName} ${e.message}")
+        error("Block failing")
+    }
+}.asPromise()
+
+

--- a/versions.properties
+++ b/versions.properties
@@ -7,63 +7,60 @@
 #### suppress inspection "SpellCheckingInspection" for whole file
 #### suppress inspection "UnusedProperty" for whole file
 
-plugin.com.avast.gradle.docker-compose=0.17.7
+plugin.com.avast.gradle.docker-compose=0.17.10
 
 plugin.org.jetbrains.dokka=1.9.20
+##             # available=2.0.0-Beta
 
-version.ch.qos.logback..logback-classic=1.5.6
+version.ch.qos.logback..logback-classic=1.5.12
 
-version.com.github.doyaaaaaken..kotlin-csv=1.9.3
+version.com.github.doyaaaaaken..kotlin-csv=1.10.0
 
-version.com.github.jillesvangurp..kotlin4example=1.1.5
+version.com.github.jillesvangurp..kotlin4example=1.1.6
 
-version.com.jillesvangurp..json-dsl=3.0.3
+version.com.jillesvangurp..json-dsl=3.0.4
 
 version.com.jillesvangurp..kotlinx-serialization-extensions=1.0.4
 
-version.io.github.microutils..kotlin-logging=3.0.5
-##                               # available=4.0.0-beta-1
-##                               # available=4.0.0-beta-2
+version.io.github.oshai..kotlin-logging=7.0.0
 
-version.junit.jupiter=5.10.3
-##        # available=5.11.0-M1
-##        # available=5.11.0-M2
+version.junit.jupiter=5.11.3
 
 version.kotest=5.9.1
+## # available=6.0.0.M1
 
-version.kotlin=2.0.0
-## # available=2.0.10-RC
-## # available=2.0.20-Beta1
-## # available=2.0.20-Beta2
+version.kotlin=2.0.21
+## # available=2.1.0-Beta1
+## # available=2.1.0-Beta2
 
 version.kotlinx.coroutines=1.8.1
 ##             # available=1.9.0-RC
+##             # available=1.9.0-RC.2
+##             # available=1.9.0
 
-version.kotlinx.datetime=0.6.0
+version.kotlinx.datetime=0.6.1
 
-version.kotlinx.serialization=1.7.1
+version.kotlinx.serialization=1.7.3
 
- version.ktor=2.3.12
-### available=3.0.0-beta-1
-### available=3.0.0-beta-2
+ version.ktor=3.0.0
 
-version.org.apache.logging.log4j..log4j-to-slf4j=2.23.1
+version.org.apache.logging.log4j..log4j-to-slf4j=2.24.1
 ##                                   # available=3.0.0-alpha1
 ##                                   # available=3.0.0-beta1
 ##                                   # available=3.0.0-beta2
 
-version.org.slf4j..jcl-over-slf4j=2.0.13
+version.org.slf4j..jcl-over-slf4j=2.0.16
 ##                    # available=2.1.0-alpha0
 ##                    # available=2.1.0-alpha1
 
-version.org.slf4j..jul-to-slf4j=2.0.13
+version.org.slf4j..jul-to-slf4j=2.0.16
 ##                  # available=2.1.0-alpha0
 ##                  # available=2.1.0-alpha1
 
-version.org.slf4j..log4j-over-slf4j=2.0.13
+version.org.slf4j..log4j-over-slf4j=2.0.16
 ##                      # available=2.1.0-alpha0
 ##                      # available=2.1.0-alpha1
 
-version.org.slf4j..slf4j-api=2.0.13
+version.org.slf4j..slf4j-api=2.0.16
 ##               # available=2.1.0-alpha0
 ##               # available=2.1.0-alpha1


### PR DESCRIPTION
WARNING: some of these changes may require you to update your other code. 
There are no API changes but ktor client 3 is a major release and if you are using v2, there may be some issues.

- add wasm support (tests for this are flaky, like js) 
- use new KotlinLogging (new package name) and remove deprecated mu.KotlinLogging  
- fix tests to clean up after themselves (avoid max shard errors when running tests repeatedly)