### PR TITLE
Add bulk response property

### DIFF
--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/bulk-api.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/bulk-api.kt
@@ -113,7 +113,7 @@ interface BulkItemCallBack {
     fun bulkRequestFailed(e: Exception, ops: List<Pair<String, String?>>)
 }
 
-class BulkException(bulkResponse: BulkResponse) : Exception(
+class BulkException(val bulkResponse: BulkResponse) : Exception(
     "Bulk request completed with errors item statuses: [${
         bulkResponse.itemDetails.map { (_, details) -> details.status }.distinct().joinToString(",")
     }]"


### PR DESCRIPTION
To make it easier to dealing with errors when `failOnFirstError = true` add the bulk response as property in the exception, currently it only logs statuses but the reasons for the errors are no longer accessible.