### PR TITLE
Move the scroll ID from the DELETE /_search/scroll URL to its body.

### DIFF
--- a/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/search-api.kt
+++ b/search-client/src/commonMain/kotlin/com/jillesvangurp/ktsearch/search-api.kt
@@ -418,7 +418,14 @@ suspend fun SearchClient.scroll(scrollId: String, scroll: Duration = 60.seconds)
 suspend fun SearchClient.deleteScroll(scrollId: String?): JsonObject {
     return if (scrollId != null) {
         restClient.delete {
-            path("_search", "scroll", scrollId)
+            path("_search", "scroll")
+            rawBody(
+                """
+                {
+                    "scroll_id": "$scrollId"
+                }
+            """.trimIndent()
+            )
         }.parseJsonObject()
     } else {
         JsonObject(emptyMap())


### PR DESCRIPTION
Scroll IDs can be too long for an HTTP request header, and so should only be put in the body. Putting them in the URL was deprecated in ElasticSearch 7.0.0 (April 2019).

The SearchClient.scroll method already does this, it was only SearchClient.deleteScroll that did not.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html