### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/src/test/kotlin/documentation/manual/bulk/indexmanagement/index-management.kt
+++ b/docs/src/test/kotlin/documentation/manual/bulk/indexmanagement/index-management.kt
@@ -17,7 +17,7 @@ val indexManagementMd = sourceGitRepository.md {
 
     section("Creating Indices") {
         +"""
-            A Crucial part of working with Elasticsearch is creating and managing indices, mappings, and settings.
+            A crucial part of working with Elasticsearch is creating and managing indices, mappings, and settings.
                     
             Getting started is easy, simply create an index like this:
         """.trimIndent()
@@ -38,8 +38,8 @@ val indexManagementMd = sourceGitRepository.md {
 
     section("Using the mappings and settings DSL") {
         +"""
-            While dynamic mapping is convenient when you are getting started, you should explictly manage your
-            index mappings. For this, kt-search provides a convenient Mapping and Settings DSL
+            While dynamic mapping is convenient when you are getting started, you should explicitly manage your
+            index mappings. For this, kt-search provides a convenient mapping and settings DSL
         """.trimIndent()
 
         example {

--- a/docs/src/test/kotlin/documentation/manual/gettingstarted/client-customization.kt
+++ b/docs/src/test/kotlin/documentation/manual/gettingstarted/client-customization.kt
@@ -16,7 +16,7 @@ val clientConfiguration = sourceGitRepository.md {
         One of the parameters on `SearchClient` is the `restClient` parameter which has a default value
         that uses the built in `KtorRestClient`. KtorRestClient has several constructors with parameters 
         with default values that you can override. The `client` parameter specifies the ktor http client
-        that is used and for this we provide a `defaultKtorHttpClient` function that creates an apprpriate
+        that is used and for this we provide a `defaultKtorHttpClient` function that creates an appropriate
         client for jvm, js, or native platforms. But of course you can create your own and choose one of the 
         many ktor client engines that are available.       
     """.trimIndent()
@@ -26,14 +26,14 @@ val clientConfiguration = sourceGitRepository.md {
         +"""
             `KtorRestClient` allows you to control in detail how to
             connect to your cluster. The default parameters simply connect to localhost on port 9200 (the default
-            http port for Elasticsearch and Opensearch. You can specify this explicitly as follows.
+            http port for Elasticsearch and Opensearch). You can specify this explicitly as follows.
         """.trimIndent()
         example {
             val client3 = SearchClient(restClient = KtorRestClient("127.0.0.1", 9200))
         }
 
         +"""
-            You may want to override some of other default parameter values to e.g. set up basic authentication and https. 
+            You may want to override some of the other default parameter values to e.g. set up basic authentication and https.
             For example, this is how you would
             connect to your cluster in Elastic Cloud using basic authentication.
         """.trimIndent()
@@ -63,8 +63,8 @@ val clientConfiguration = sourceGitRepository.md {
         }
 
         +"""
-            For Opensearch clusters in AWS, you need to use Amazon's [sigv4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html) to sign requests. This is currently 
-            not directly supported directly in the client. However, it should be pretty easy to construct your own rest client that does this.
+            For Opensearch clusters in AWS, you need to use Amazon's [sigv4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html) to sign requests. This is currently
+            not directly supported in the client. However, it should be pretty easy to construct your own REST client that does this.
              
              See this [gist](https://gist.github.com/hassaku63/e3ed3cac288d429563cdddf1768613d6) on how
              to do curl requests against an AWS Opensearch cluster.
@@ -72,9 +72,9 @@ val clientConfiguration = sourceGitRepository.md {
             To work around this, you can provide your own customized ktor client that 
              does this; or provide an alternative `RestClient` implementation in case you don't want to use ktor client. 
              
-             Pull requests that document authenticating with opensearch in AWS in more detail 
-             or enable this in a multi platform way with the ktor client are welcome. I currently
-             do not have access to an opensearch cluster in AWS.
+             Pull requests that document authenticating with Opensearch in AWS in more detail
+             or enable this in a multiplatform way with the ktor client are welcome. I currently
+             do not have access to an Opensearch cluster in AWS.
         """.trimIndent()
 
     }
@@ -117,9 +117,9 @@ val clientConfiguration = sourceGitRepository.md {
              cluster nodes from the cluster. This strategy is useful if you need to perform cluster 
              modifications without downtime. E.g. adding new nodes to the cluster and removing existing nodes
              during an update would cause the node configuration you used to get out of date. The 
-             `SniffingNodeSelector` updates it's list of nodes as this happens and you should not need
+             `SniffingNodeSelector` updates its list of nodes as this happens and you should not need
              to restart your application servers. At least not right away, you may still want to update
-             it's initial list of nodes of course.
+             its initial list of nodes of course.
             
         """.trimIndent()
 
@@ -141,12 +141,12 @@ val clientConfiguration = sourceGitRepository.md {
         }
 
         +"""
-            To control which node is used with the `SniffingNodeSelector`, you can use an `AffinityId` co routine scope. 
-            
-            This ensures that repeated calls within the same co-routine scope use the same client. Without this, 
+            To control which node is used with the `SniffingNodeSelector`, you can use an `AffinityId` coroutine scope.
+
+            This ensures that repeated calls within the same coroutine scope use the same client. Without this,
             it uses the thread name as the affinityId (jvm only) or randomly picks an active node (other platforms). 
             
-            Using an affinity id helps performance a bit if you do multiple elastic search calls
+            Using an affinity id helps performance a bit if you do multiple Elasticsearch calls
             in one web request or transaction and benefits from http pipelining and connection reuse.
             
             Regardless of whether you use an affinity id, the node list is refreshed periodically (as per the `maxNodeAge` parameter).

--- a/docs/src/test/kotlin/documentation/manual/gettingstarted/getting-started.kt
+++ b/docs/src/test/kotlin/documentation/manual/gettingstarted/getting-started.kt
@@ -44,13 +44,13 @@ val gettingStartedMd = sourceGitRepository.md {
 
     section("Using the client") {
         +"""
-            After creating the client, you can use it. Since kt-search uses non blocking IO via ktor client, all 
-            calls are suspending and have to be inside a co-routine.
+            After creating the client, you can use it. Since kt-search uses non-blocking IO via ktor client, all
+            calls are suspending and have to be inside a coroutine.
         """.trimIndent()
 
         example {
             // use a simple runBlocking
-            // normally you would get a co-routine via e.g. Spring's flux async framework.
+            // normally you would get a coroutine via e.g. Spring's flux async framework.
             runBlocking {
                 // call the root API with some version information
                 client.root().let { resp ->
@@ -77,7 +77,7 @@ val gettingStartedMd = sourceGitRepository.md {
             val results = client.search("myindex") {
                 query = matchPhrase(
                     field = "title",
-                    query = "lorum ipsum")
+                  query = "lorem ipsum")
             }
 
             // returns a list of MyModelClass

--- a/docs/src/test/kotlin/documentation/manual/gettingstarted/whatisktsearch.md
+++ b/docs/src/test/kotlin/documentation/manual/gettingstarted/whatisktsearch.md
@@ -26,13 +26,13 @@ The whole point of kt-search is to provide a best in class developer experience 
 
 ## Kt Search 2.0 - What's new and what is different
 
-A few years of development on the es-kotlin-client has produced quite a few learnings. Additionally, I added a lot of features over time and gradually introduced things like asynchronous IO using Kotlin co-routines, Query DSL support, and a few other things. These are all things that ended up being useful and preserved in the new client.
+ A few years of development on the es-kotlin-client has produced quite a few learnings. Additionally, I added a lot of features over time and gradually introduced things like asynchronous IO using Kotlin coroutines, Query DSL support, and a few other things. These are all things that ended up being useful and preserved in the new client.
 
-- Kotlin multi-platform and no more Java dependencies, such as the RestHighLevelClient. You can use kt-search in browsers using kotlin-js and on the jvm.
+ - Kotlin multiplatform and no more Java dependencies, such as the RestHighLevelClient. You can use kt-search in browsers using kotlin-js and on the jvm.
 - You can still plug in custom HTTP and Json parsers and still use your favorite libraries for that on the JVM. However, the default setup uses `ktor-client` for http communication and `kotlinx-serialization` for JSON parsing.
 - With Kt-Search, the Kotlin Query DSL stays mostly the same (but with some additions of course) and has moved to its own module. Aside from some package renames and minor feature work, the DSL should be backwards compatible with the one bundled with the es-kotlin client.
 - More DSLs. Since building Json DSLs seems like a nice feature to have, I extracted the classes that I used as a basis for the query, mapping, and other DSLs to a separate module called `json-dsl`. So, in addition to querying there are now also DSLs for mappings and settings, index life cycle management, templates, and more.
-- All IO is now done using `suspend` functions and co-routines. I've found that I did not ever use the synchronous calls in the old es-kotlin-client and doing synchronous IO in Kotlin does not make a lot of sense. Especially not in a multi-platform library as the IO support for multi-platform kotlin is of course asynchronous only.
+ - All IO is now done using `suspend` functions and coroutines. I've found that I did not ever use the synchronous calls in the old es-kotlin-client and doing synchronous IO in Kotlin does not make a lot of sense. Especially not in a multiplatform library as the IO support for multiplatform Kotlin is of course asynchronous only.
 - Functionality similar to the Repository class in the es-kotlin-client is also supported in Kt-Search. However, there were some API changes as we no longer can rely on Elastic's Java response model classes. Where needed, similar classes are provided for Kotlin and those are parsed with `kotlinx-serialization`.
 - Kt-search is now asynchronous only. Blocking IO in Kotlin just doesn't make a lot of sense and it's easy to make everything suspending. If you really need blocking behavior, just surround it with a `runBlocking`.
 
@@ -46,7 +46,7 @@ The rewrite in `kt-search` 2.0 was necessitated by the deprecation of Elastic's 
 
 However, Elasticsearch and Opensearch still share the same REST API with only very minor variations mostly related to advanced features. For most common uses they are identical products.
 
-Kt-search, removes the dependency on the Java client entirely. This in turn makes it possible to use all the wonderful new libraries in the Kotlin ecosystem. Therefore, it also is a **Kotlin multi-platform library**. This is a feature we get for free simply by using what is there. Kotlin-multi platform makes it possible to use Elasticsearch or Opensearch on any platform where you can compile this library.
+Kt-search, removes the dependency on the Java client entirely. This in turn makes it possible to use all the wonderful new libraries in the Kotlin ecosystem. Therefore, it also is a **Kotlin multiplatform library**. This is a feature we get for free simply by using what is there. Kotlin multiplatform makes it possible to use Elasticsearch or Opensearch on any platform where you can compile this library.
 
 Currently, that includes the **jvm** and **kotlin-js** compilers. However, it should be straightforward to compile this for e.g. IOS or linux as well using the **kotlin-native** compiler and the new **wasm** compiler. I just lack a project to test all this properly.
 

--- a/docs/src/test/kotlin/documentation/manual/scripting/sampleScript.md
+++ b/docs/src/test/kotlin/documentation/manual/scripting/sampleScript.md
@@ -23,7 +23,7 @@ parser.parse(args)
 // extension function in kt-search-kts that uses the params
 val client = searchClientParams.searchClient
 
-// now use the client as normally in a runBlocking block (creates a co-routine)
+// now use the client as normally in a runBlocking block (creates a coroutine)
 runBlocking {
     val clusterStatus=client.clusterHealth()
     client.root().let {

--- a/docs/src/test/kotlin/documentation/manual/scripting/scripting.kt
+++ b/docs/src/test/kotlin/documentation/manual/scripting/scripting.kt
@@ -75,8 +75,8 @@ val scriptingMd = sourceGitRepository.md {
               that means that defining new serializable data classes is not possible in 
               KTS unless you can add the compiler plugin. There are some workarounds for that documented 
               here: https://youtrack.jetbrains.com/issue/KT-47384. Alternatively, put your model classes in a separate library (that builds with the compiler plugin) and add a dependency to that.             
-            - KTS is a bit limited in with respect to handling multi-platform dependencies. 
-              Make sure to depend on the `-jvm` dependency for multi-platform dependencies 
+            - KTS is a bit limited with respect to handling multiplatform dependencies.
+                Make sure to depend on the `-jvm` dependency for multiplatform dependencies
               (like kt-search). The `kt-search-kts` library has a transitive dependency and that 
               works out fine.
             - if you add a custom repository, you also have to specify maven 

--- a/docs/src/test/kotlin/documentation/manual/search/specialized-queries.kt
+++ b/docs/src/test/kotlin/documentation/manual/search/specialized-queries.kt
@@ -145,7 +145,7 @@ val specializedQueriesMd = sourceGitRepository.md {
             - saturation (default). Uses a default pivot based on the mean value of the rank_feature field. Or you can provide custom one
             - sigmoid. Similar to saturation but uses an exponential that you (typically) learn from your data.
             - log. Logarithmic function with a scaling factory that you can specify.
-            - linear. Simple linear score based on te numeric value.
+            - linear. Simple linear score based on the numeric value.
         """.trimIndent()
 
         example(runExample = false) {

--- a/docs/src/test/kotlin/documentation/projectreadme/gradle-maven.md
+++ b/docs/src/test/kotlin/documentation/projectreadme/gradle-maven.md
@@ -22,7 +22,7 @@ And then add the dependency like this:
 ```
 Note, several of the search-client dependencies for ktor client are marked as implementation. This means you have to explicitly add those on your side. This is intentional as some people may want to use their own rest client with the kt-search search client.
 
-If you use the KtorRestClient that comes with kt-search you need to add the relevant ktor dependencies for the lates ktor-client 3.x:
+If you use the KtorRestClient that comes with kt-search you need to add the relevant ktor dependencies for the latest ktor client 3.x:
 
 ```kotlin
 implementation("io.ktor:ktor-client-core:3.x.y")

--- a/docs/src/test/kotlin/documentation/projectreadme/readme-intro.md
+++ b/docs/src/test/kotlin/documentation/projectreadme/readme-intro.md
@@ -1,12 +1,12 @@
 ## Why Kt-search?
 
-If you develop software in Kotlin and would like to use Opensearch or Elasticsearch, you have a few choices to make. There are multiple clients to choose from and not all of them work for each version. And then there is Kotlin multi platform to consider as well. Maybe you are running spring boot on the jvm. Or maybe you are using ktor compiled to native or WASM and using that to run lambda functions. 
+If you develop software in Kotlin and would like to use Opensearch or Elasticsearch, you have a few choices to make. There are multiple clients to choose from and not all of them work for each version. And then there is Kotlin multiplatform to consider as well. Maybe you are running spring boot on the jvm. Or maybe you are using ktor compiled to native or WASM and using that to run lambda functions.
 
 Kt-search has you covered for all of those. The official Elastic or Opensearch clients are Java clients. You can use them from Kotlin but only on the JVM. And they are not source compatible with each other. The Opensearch client is based on a fork of the old Java client which after the fork was deprecated. On top of that, it uses opensearch specific package names.
 
 Kt-search solves a few important problems here:
 
-- It's Kotlin! You don't have to deal with all the Java idiomatic stuff that comes with the three Java libraries. You can write pure Kotlin code, use co-routines, and use Kotlin DSLs for everything. Simpler code, easier to debug, etc.
+ - It's Kotlin! You don't have to deal with all the Java idiomatic stuff that comes with the three Java libraries. You can write pure Kotlin code, use coroutines, and use Kotlin DSLs for everything. Simpler code, easier to debug, etc.
 - It's a multiplatform library. We use it on the jvm and in the browser (javascript). Targets for native, IOS, WASM, etc. are also there. So, your Kotlin code should be extremely portable. So, whether you are doing backend development, doing lambda functions, command line tools, mobile apps, or web apps, you can embed kt-search in each of those.
 - It doesn't force you to choose between Elasticsearch or Opensearch. Some features are specific to those products and will only work for those platforms but most of the baseline functionality is exactly the same for both.
 - It's future proof. Everything is extensible (DSLs) and modular. Even supporting custom plugins that add new features is pretty easy with the `json-dsl` library that is part of kt-search.

--- a/docs/src/test/kotlin/documentation/projectreadme/readme-outro.md
+++ b/docs/src/test/kotlin/documentation/projectreadme/readme-outro.md
@@ -51,7 +51,7 @@ onlyOn("doesn't work on Opensearch",
 
 New releases of this library generally update dependencies to their current versions. There currently is no LTS release of Kotlin. Generally this library should work with recent stable releases of Kotlin. At this point, that means Kotlin 2.0 or higher.
 
-Also, because this is a multi platform project, you should be aware that several of the platforms are experimental. Because of this, we try to track the latest stable releases of Kotlin. IOS, Linux, Wasm, etc. are expected to generally work but are not something that we actively use ourselves and something that at this point is not stable on the Kotlin side yet. Also, there are some issues with WASM and Karma not playing nice. I've disabled tests for that. The IOS simulator tests are disabled for the same reason.
+Also, because this is a multiplatform project, you should be aware that several of the platforms are experimental. Because of this, we try to track the latest stable releases of Kotlin. IOS, Linux, Wasm, etc. are expected to generally work but are not something that we actively use ourselves and something that at this point is not stable on the Kotlin side yet. Also, there are some issues with WASM and Karma not playing nice. I've disabled tests for that. The IOS simulator tests are disabled for the same reason.
 
 If you try and find issues, use the issue tracker please.
 

--- a/docs/src/test/kotlin/documentation/projectreadme/readme.kt
+++ b/docs/src/test/kotlin/documentation/projectreadme/readme.kt
@@ -94,13 +94,13 @@ val projectReadme = sourceGitRepository.md {
             part of the code dependent on kotlinx serialization is the client module. But for example the Search DSL 
              and the other DSLs are not actually dependent on this.
              
-            Additionally, if you chooes to use the `IndexRepository`, it comes with a ModelSerialization strategy 
+            Additionally, if you choose to use the `IndexRepository`, it comes with a ModelSerialization strategy
             that abstracts how to parse/serialize your model classes. A kotlinx serialization implementation is included
             but that's easily swapped out for something else. So, if you need to use e.g. 
             jackson or gson instead, you can do so easily. However, kotlinx serialization is of course the only thing
-            that works on multi platform.
+            that works on multiplatform.
             
-            ### Creating  an index
+            ### Creating an index
                        
             Before we can query for `TestDocument` documents, we need to create an index and store some objects:
             


### PR DESCRIPTION
## Summary
- fix spelling and grammar throughout docs module
- clean up coroutine and multiplatform terminology
- correct examples and dependency hints

## Testing
- `./gradlew :docs:test --rerun-tasks` *(fails: Could not resolve com.github.jillesvangurp:kotlin4example:1.1.6)*

------
https://chatgpt.com/codex/tasks/task_e_68959a9bac78832eb2d83d3e8d71e715