### PR TITLE
Add histogram aggregation DSL and docs

### DIFF
--- a/docs/src/test/kotlin/documentation/manual/search/aggregations.kt
+++ b/docs/src/test/kotlin/documentation/manual/search/aggregations.kt
@@ -47,7 +47,8 @@ val aggregationsMd = sourceGitRepository.md {
         val name: String,
         val tags: List<String>? = null,
         val color: String? = null,
-        val timestamp: Instant? = null
+        val timestamp: Instant? = null,
+        val value: Double? = null,
     )
 
     val repo = client.repository(indexName, MockDoc.serializer())
@@ -78,7 +79,8 @@ val aggregationsMd = sourceGitRepository.md {
             val name: String,
             val tags: List<String>? = null,
             val color: String? = null,
-            val timestamp: Instant? = null
+            val timestamp: Instant? = null,
+            val value: Double? = null,
         )
 
         val indexName = "docs-aggs-demo"
@@ -88,6 +90,7 @@ val aggregationsMd = sourceGitRepository.md {
                 keyword(MockDoc::color)
                 keyword(MockDoc::tags)
                 date(MockDoc::timestamp)
+                number<Double>(MockDoc::value)
             }
         }
 
@@ -99,7 +102,8 @@ val aggregationsMd = sourceGitRepository.md {
                     name = "1",
                     tags = listOf("bar"),
                     color = "green",
-                    timestamp = now
+                    timestamp = now,
+                    value = 3.0,
                 )
             )
             index(
@@ -107,7 +111,8 @@ val aggregationsMd = sourceGitRepository.md {
                     name = "2",
                     tags = listOf("foo"),
                     color = "red",
-                    timestamp = now - 1.days
+                    timestamp = now - 1.days,
+                    value = 12.5,
                 )
             )
             index(
@@ -115,7 +120,8 @@ val aggregationsMd = sourceGitRepository.md {
                     name = "3",
                     tags = listOf("foo", "bar"),
                     color = "red",
-                    timestamp = now - 5.days
+                    timestamp = now - 5.days,
+                    value = 21.0,
                 )
             )
             index(
@@ -123,7 +129,8 @@ val aggregationsMd = sourceGitRepository.md {
                     name = "4",
                     tags = listOf("foobar"),
                     color = "green",
-                    timestamp = now - 10.days
+                    timestamp = now - 10.days,
+                    value = null,
                 )
             )
         }
@@ -445,10 +452,31 @@ val aggregationsMd = sourceGitRepository.md {
     section("Other aggregations") {
         +"""
             Here is a more complicated example where we use various other aggregations.
-            
+
             Note, we do not support all aggregations currently but it's easy to add
             support for more as needed. Pull requests for this are welcome.
         """.trimIndent()
+
+        +"""
+            Numeric histograms bucket numeric fields into fixed ranges. Use `offset` to shift the
+            bucket boundaries, `missing` to control how null values are counted, and `extended_bounds`
+            or `hard_bounds` to force buckets at the edges of the range.
+        """.trimIndent()
+
+        example {
+            val response = repo.search {
+                resultSize = 0 // we only care about the aggs
+                agg("by_value", HistogramAgg(MockDoc::value, interval = 10) {
+                    offset = 2
+                    minDocCount = 0
+                    missing = 0
+                    extendedBounds(min = 0, max = 30)
+                    hardBounds(min = 0, max = 30)
+                })
+            }
+
+            println(DEFAULT_PRETTY_JSON.encodeToString(response))
+        }.printStdOut(this)
 
         example {
             val response = repo.search {

--- a/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/aggregation-queries.kt
+++ b/search-dsls/src/commonMain/kotlin/com/jillesvangurp/searchdsls/querydsl/aggregation-queries.kt
@@ -365,6 +365,49 @@ class DateHistogramAgg(val field: String, block: (DateHistogramAggConfig.() -> U
     }
 }
 
+class HistogramAggConfig : JsonDsl() {
+    var field by property<String>()
+    var interval by property<Number>()
+    var offset by property<Number>()
+    var minDocCount by property<Long>("min_doc_count")
+    var missing by property<Number>()
+
+    fun extendedBounds(min: Number? = null, max: Number? = null) {
+        if (min != null || max != null) {
+            this["extended_bounds"] = withJsonDsl {
+                this["min"] = min
+                this["max"] = max
+            }
+        }
+    }
+
+    fun hardBounds(min: Number? = null, max: Number? = null) {
+        if (min != null || max != null) {
+            this["hard_bounds"] = withJsonDsl {
+                this["min"] = min
+                this["max"] = max
+            }
+        }
+    }
+}
+
+class HistogramAgg(
+    val field: String,
+    val interval: Number,
+    block: (HistogramAggConfig.() -> Unit)? = null,
+) : AggQuery("histogram") {
+    constructor(field: KProperty<*>, interval: Number, block: (HistogramAggConfig.() -> Unit)? = null) :
+        this(field.name, interval, block)
+
+    init {
+        val config = HistogramAggConfig()
+        config.field = field
+        config.interval = interval
+        block?.invoke(config)
+        put(name, config)
+    }
+}
+
 class ExtendedStatsBucketAggConfig : JsonDsl() {
     var bucketsPath by property<String>("buckets_path")
     var gapPolicy by property<String>("gap_policy")

--- a/search-dsls/src/commonTest/kotlin/com/jillesvangurp/searchdsls/querydsl/HistogramAggTest.kt
+++ b/search-dsls/src/commonTest/kotlin/com/jillesvangurp/searchdsls/querydsl/HistogramAggTest.kt
@@ -1,0 +1,64 @@
+package com.jillesvangurp.searchdsls.querydsl
+
+import com.jillesvangurp.jsondsl.withJsonDsl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HistogramAggTest {
+    @Test
+    fun `should serialize basic histogram agg`() {
+        val searchDsl = SearchDSL().apply {
+            agg("prices", HistogramAgg("price", interval = 5))
+        }
+
+        val expected = withJsonDsl {
+            this["aggs"] = withJsonDsl {
+                this["prices"] = withJsonDsl {
+                    this["histogram"] = withJsonDsl {
+                        this["field"] = "price"
+                        this["interval"] = 5
+                    }
+                }
+            }
+        }
+
+        assertEquals(expected.toString(), searchDsl.toString())
+    }
+
+    @Test
+    fun `should serialize histogram bounds and missing`() {
+        val searchDsl = SearchDSL().apply {
+            agg("prices", HistogramAgg("price", interval = 10) {
+                offset = 2
+                minDocCount = 1
+                missing = 0
+                extendedBounds(min = 0, max = 50)
+                hardBounds(min = 0, max = 60)
+            })
+        }
+
+        val expected = withJsonDsl {
+            this["aggs"] = withJsonDsl {
+                this["prices"] = withJsonDsl {
+                    this["histogram"] = withJsonDsl {
+                        this["field"] = "price"
+                        this["interval"] = 10
+                        this["offset"] = 2
+                        this["min_doc_count"] = 1L
+                        this["missing"] = 0
+                        this["extended_bounds"] = withJsonDsl {
+                            this["min"] = 0
+                            this["max"] = 50
+                        }
+                        this["hard_bounds"] = withJsonDsl {
+                            this["min"] = 0
+                            this["max"] = 60
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(expected.toString(), searchDsl.toString())
+    }
+}


### PR DESCRIPTION
## Summary
- add a histogram aggregation DSL with support for offsets, bounds, missing values, and minimum document counts
- cover histogram serialization with new DSL unit tests
- document numeric histogram usage and extend the example data to include numeric values

## Testing
- ./gradlew :search-dsls:jvmTest
- ./gradlew :docs:test --tests documentation.DocumentationTest *(fails: DocumentationTest hits java.net.ConnectException because Elasticsearch is not running in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938745a0eb8832eb7589e30f6a268b7)