### PR TITLE
Add schema/alias export and id-aware dump/restore

### DIFF
--- a/ktsearch-cli/alias-and-completions.sh
+++ b/ktsearch-cli/alias-and-completions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Usage: source ./ktsearch-temp.sh
+# (must be sourced, not executed, so alias/completion stay in current shell)
+
+# After you upload the jar file and install java on your remote machine, source this to get the cli
+KTSEARCH_JAR="/root/ktsearch-cli-all.jar"
+
+if [[ ! -f "$KTSEARCH_JAR" ]]; then
+  echo "Jar not found: $KTSEARCH_JAR" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Temporary alias for this shell session
+alias ktsearch="java -jar $KTSEARCH_JAR"
+
+# Detect current shell and install completion in-memory
+if [[ -n "${BASH_VERSION:-}" ]]; then
+  eval "$("java" -jar "$KTSEARCH_JAR" completion bash)"
+  echo "ktsearch alias + bash completion loaded for this session."
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+  autoload -Uz compinit
+  compinit -u
+  eval "$("java" -jar "$KTSEARCH_JAR" completion zsh)"
+  echo "ktsearch alias + zsh completion loaded for this session."
+else
+  echo "Unsupported shell for auto-completion. Alias loaded only."
+fi

--- a/ktsearch-cli/cli-manual.md
+++ b/ktsearch-cli/cli-manual.md
@@ -1674,7 +1674,6 @@ Options:
   --refresh=(wait_for|true|false)   Refresh mode: wait_for|true|false.
   --pipeline=<text>                 Ingest pipeline for restore indexing.
   --routing=<text>                  Routing value for all restored docs.
-  --id-field=<text>                 Extract document id from this JSON field per line.
   --disable-refresh-interval        Temporarily set index refresh_interval to -1.
   --set-replicas-zero               Temporarily set index number_of_replicas to 0.
   --schema                          Load <index>-schema.json and create target index from it.

--- a/ktsearch-cli/cli-manual.md
+++ b/ktsearch-cli/cli-manual.md
@@ -1651,6 +1651,8 @@ Usage: ktsearch index dump [<options>] <index>
 Options:
   --output=<text>  Output file path. Defaults to <index>.ndjson.gz.
   -y, --yes        Overwrite without confirmation if file exists.
+  --schema         Also export <index>-schema.json with mappings and settings.
+  --aliases        Also export <index>-aliases.json with aliases for index.
   -h, --help       Show this message and exit
 
 Arguments:
@@ -1675,6 +1677,8 @@ Options:
   --id-field=<text>                 Extract document id from this JSON field per line.
   --disable-refresh-interval        Temporarily set index refresh_interval to -1.
   --set-replicas-zero               Temporarily set index number_of_replicas to 0.
+  --schema                          Load <index>-schema.json and create target index from it.
+  --aliases                         Load <index>-aliases.json and apply aliases before restore.
   -y, --yes                         Do not prompt for destructive actions.
   -h, --help                        Show this message and exit
 

--- a/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/CliService.kt
+++ b/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/CliService.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
@@ -74,6 +75,16 @@ interface CliService {
         index: String,
         writer: NdjsonGzipWriter,
     ): Long
+
+    suspend fun exportIndexSchema(
+        connectionOptions: ConnectionOptions,
+        index: String,
+    ): String
+
+    suspend fun exportIndexAliases(
+        connectionOptions: ConnectionOptions,
+        index: String,
+    ): String
 
     suspend fun searchIndexRaw(
         connectionOptions: ConnectionOptions,
@@ -121,6 +132,8 @@ interface CliService {
         idField: String? = null,
         disableRefreshInterval: Boolean = false,
         setReplicasToZero: Boolean = false,
+        schemaJson: String? = null,
+        aliasesJson: String? = null,
     ): Long
 
     suspend fun reindex(
@@ -387,6 +400,46 @@ class DefaultCliService : CliService {
         }
     }
 
+    override suspend fun exportIndexSchema(
+        connectionOptions: ConnectionOptions,
+        index: String,
+    ): String {
+        return runWithCliErrorMapping(connectionOptions) {
+            val client = createClient(connectionOptions)
+            try {
+                val settingsRaw = client.restClient.get {
+                    path(index, "_settings")
+                }.getOrThrow().text
+                val mappingsRaw = client.restClient.get {
+                    path(index, "_mappings")
+                }.getOrThrow().text
+                composeSchemaJson(
+                    index = index,
+                    settingsRaw = settingsRaw,
+                    mappingsRaw = mappingsRaw,
+                )
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    override suspend fun exportIndexAliases(
+        connectionOptions: ConnectionOptions,
+        index: String,
+    ): String {
+        return runWithCliErrorMapping(connectionOptions) {
+            val client = createClient(connectionOptions)
+            try {
+                client.restClient.get {
+                    path(index, "_alias")
+                }.getOrThrow().text
+            } finally {
+                client.close()
+            }
+        }
+    }
+
     override suspend fun searchIndexRaw(
         connectionOptions: ConnectionOptions,
         index: String,
@@ -536,16 +589,47 @@ class DefaultCliService : CliService {
         idField: String?,
         disableRefreshInterval: Boolean,
         setReplicasToZero: Boolean,
+        schemaJson: String?,
+        aliasesJson: String?,
     ): Long {
         return runWithCliErrorMapping(connectionOptions) {
             val client = createClient(connectionOptions)
             try {
-                val indexExists = client.exists(index)
-                if (recreate && indexExists) {
-                    client.deleteIndex(index, ignoreUnavailable = true)
+                var indexExists = client.exists(index)
+                if (schemaJson != null) {
+                    if (indexExists && !recreate) {
+                        throw UsageError(
+                            "Target index '$index' already exists. " +
+                                "Use --recreate with --schema.",
+                        )
+                    }
+                    if (recreate && indexExists) {
+                        client.deleteIndex(index, ignoreUnavailable = true)
+                        indexExists = false
+                    }
+                    if (!indexExists) {
+                        client.restClient.put {
+                            path(index)
+                            rawBody(schemaJson)
+                        }.getOrThrow()
+                        indexExists = true
+                    }
+                } else {
+                    if (recreate && indexExists) {
+                        client.deleteIndex(index, ignoreUnavailable = true)
+                        indexExists = false
+                    }
+                    if (recreate || (createIfMissing && !indexExists)) {
+                        client.createIndex(index)
+                        indexExists = true
+                    }
                 }
-                if (recreate || (createIfMissing && !indexExists)) {
-                    client.createIndex(index)
+                if (aliasesJson != null) {
+                    val actionsBody = composeAliasActions(index, aliasesJson)
+                    client.restClient.post {
+                        path("_aliases")
+                        rawBody(actionsBody)
+                    }.getOrThrow()
                 }
 
                 suspend fun runRestore(): Long {
@@ -924,4 +1008,78 @@ private fun withExtraProfile(data: String, profile: Boolean): String {
     } catch (_: Exception) {
         data
     }
+}
+
+internal fun composeSchemaJson(
+    index: String,
+    settingsRaw: String,
+    mappingsRaw: String,
+): String {
+    val settingsRoot = Json.parseToJsonElement(settingsRaw).jsonObject
+    val mappingsRoot = Json.parseToJsonElement(mappingsRaw).jsonObject
+    val settingsForIndex = settingsRoot[index]?.jsonObject
+        ?.get("settings")?.jsonObject
+        ?.let { sanitizeIndexSettings(it) }
+    val mappingsForIndex = mappingsRoot[index]?.jsonObject
+        ?.get("mappings")?.jsonObject
+    return buildJsonObject {
+        settingsForIndex?.let { put("settings", it) }
+        mappingsForIndex?.let { put("mappings", it) }
+    }.toString()
+}
+
+internal fun sanitizeIndexSettings(settings: JsonObject): JsonObject {
+    val indexSettings = settings["index"]?.jsonObject ?: return settings
+    val ignoredIndexKeys = setOf(
+        "uuid",
+        "version",
+        "provided_name",
+        "creation_date",
+        "creation_date_string",
+    )
+    val sanitizedIndex = buildJsonObject {
+        indexSettings.forEach { (key, value) ->
+            if (key !in ignoredIndexKeys) {
+                put(key, value)
+            }
+        }
+    }
+    return buildJsonObject {
+        settings.forEach { (key, value) ->
+            if (key == "index") {
+                put(key, sanitizedIndex)
+            } else {
+                put(key, value)
+            }
+        }
+    }
+}
+
+internal fun composeAliasActions(index: String, aliasesRaw: String): String {
+    val aliasesRoot = Json.parseToJsonElement(aliasesRaw).jsonObject
+    val aliases = aliasesRoot[index]?.jsonObject?.get("aliases")?.jsonObject
+        ?: JsonObject(emptyMap())
+    val actions = buildJsonArray {
+        aliases.forEach { (aliasName, aliasDefinition) ->
+            add(
+                buildJsonObject {
+                    put(
+                        "add",
+                        buildJsonObject {
+                            put("index", JsonPrimitive(index))
+                            put("alias", JsonPrimitive(aliasName))
+                            if (aliasDefinition is JsonObject) {
+                                aliasDefinition.forEach { (key, value) ->
+                                    put(key, value)
+                                }
+                            }
+                        },
+                    )
+                },
+            )
+        }
+    }
+    return buildJsonObject {
+        put("actions", actions)
+    }.toString()
 }

--- a/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/CliService.kt
+++ b/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/CliService.kt
@@ -129,7 +129,6 @@ interface CliService {
         refresh: String = "wait_for",
         pipeline: String? = null,
         routing: String? = null,
-        idField: String? = null,
         disableRefreshInterval: Boolean = false,
         setReplicasToZero: Boolean = false,
         schemaJson: String? = null,
@@ -386,10 +385,10 @@ class DefaultCliService : CliService {
                 flow.collect { hit ->
                     val source = hit.source
                         ?: error("Hit ${hit.index}/${hit.id} has no _source")
-                    val line = client.json.encodeToString(
-                        JsonObject.serializer(),
-                        source,
-                    )
+                    val line = buildJsonObject {
+                        put("_id", JsonPrimitive(hit.id))
+                        put("_source", source)
+                    }.toString()
                     writer.writeLine(line)
                     lines++
                 }
@@ -586,7 +585,6 @@ class DefaultCliService : CliService {
         refresh: String,
         pipeline: String?,
         routing: String?,
-        idField: String?,
         disableRefreshInterval: Boolean,
         setReplicasToZero: Boolean,
         schemaJson: String?,
@@ -649,23 +647,8 @@ class DefaultCliService : CliService {
                             if (trimmed.isEmpty()) {
                                 continue
                             }
-                            val id = idField?.let { key ->
-                                runCatching {
-                                    Json.Default
-                                        .decodeFromString(
-                                            JsonObject.serializer(),
-                                            trimmed,
-                                        ).get(key)
-                                        ?.let { value ->
-                                            if (value is JsonPrimitive) {
-                                                value.content
-                                            } else {
-                                                value.toString()
-                                            }
-                                        }
-                                }.getOrNull()
-                            }
-                            session.index(source = trimmed, id = id)
+                            val parsed = parseDumpLine(trimmed, lines + 1)
+                            session.index(source = parsed.source, id = parsed.id)
                             lines++
                         }
                         session.flush()
@@ -1082,4 +1065,36 @@ internal fun composeAliasActions(index: String, aliasesRaw: String): String {
     return buildJsonObject {
         put("actions", actions)
     }.toString()
+}
+
+internal data class DumpLine(
+    val id: String,
+    val source: String,
+)
+
+internal fun parseDumpLine(
+    line: String,
+    lineNumber: Long,
+): DumpLine {
+    val parsed = runCatching {
+        Json.parseToJsonElement(line).jsonObject
+    }.getOrElse {
+        throw UsageError(
+            "Invalid dump format at line $lineNumber: expected JSON object " +
+                "with _id and _source.",
+        )
+    }
+    val id = parsed["_id"]?.jsonPrimitive?.contentOrNull
+    if (id.isNullOrBlank()) {
+        throw UsageError(
+            "Invalid dump format at line $lineNumber: _id is required.",
+        )
+    }
+    val source = parsed["_source"]?.jsonObject ?: throw UsageError(
+        "Invalid dump format at line $lineNumber: _source object is required.",
+    )
+    return DumpLine(
+        id = id,
+        source = source.toString(),
+    )
 }

--- a/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/command/index/dump/DumpCommand.kt
+++ b/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/command/index/dump/DumpCommand.kt
@@ -9,6 +9,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.jillesvangurp.ktsearch.cli.CliPlatform
 import com.jillesvangurp.ktsearch.cli.CliService
 import com.jillesvangurp.ktsearch.cli.ConnectionOptions
+import com.jillesvangurp.ktsearch.cli.platformWriteUtf8File
 
 class DumpCommand(
     private val service: CliService,
@@ -30,23 +31,31 @@ class DumpCommand(
         help = "Overwrite without confirmation if file exists.",
     ).flag(default = false)
 
+    private val schema by option(
+        "--schema",
+        help = "Also export <index>-schema.json with mappings and settings.",
+    ).flag(default = false)
+
+    private val aliases by option(
+        "--aliases",
+        help = "Also export <index>-aliases.json with aliases for index.",
+    ).flag(default = false)
+
     override suspend fun run() {
         val connectionOptions = currentContext.findObject<ConnectionOptions>()
             ?: error("Missing connection options in command context")
 
         val outputPath = output ?: "$index.ndjson.gz"
+        val outputDir = parentDir(outputPath)
+        val schemaPath = joinPath(outputDir, "$index-schema.json")
+        val aliasesPath = joinPath(outputDir, "$index-aliases.json")
 
-        if (platform.fileExists(outputPath) && !yes) {
-            if (!platform.isInteractiveInput()) {
-                currentContext.fail(
-                    "$outputPath exists; use --yes to overwrite in non-interactive mode",
-                )
-            }
-            echo("$outputPath exists. Overwrite? [y/N]")
-            val answer = platform.readLineFromStdin()?.trim().orEmpty()
-            if (!isYes(answer)) {
-                currentContext.fail("Aborted. File exists: $outputPath")
-            }
+        confirmOverwriteIfNeeded(path = outputPath)
+        if (schema) {
+            confirmOverwriteIfNeeded(path = schemaPath)
+        }
+        if (aliases) {
+            confirmOverwriteIfNeeded(path = aliasesPath)
         }
 
         val writer = platform.createGzipWriter(outputPath)
@@ -57,6 +66,32 @@ class DumpCommand(
         }
 
         echo("wrote $lines lines to $outputPath")
+        if (schema) {
+            val schemaJson = service.exportIndexSchema(connectionOptions, index)
+            platformWriteUtf8File(schemaPath, schemaJson)
+            echo("wrote schema to $schemaPath")
+        }
+        if (aliases) {
+            val aliasesJson = service.exportIndexAliases(connectionOptions, index)
+            platformWriteUtf8File(aliasesPath, aliasesJson)
+            echo("wrote aliases to $aliasesPath")
+        }
+    }
+
+    private fun confirmOverwriteIfNeeded(path: String) {
+        if (!platform.fileExists(path) || yes) {
+            return
+        }
+        if (!platform.isInteractiveInput()) {
+            currentContext.fail(
+                "$path exists; use --yes to overwrite in non-interactive mode",
+            )
+        }
+        echo("$path exists. Overwrite? [y/N]")
+        val answer = platform.readLineFromStdin()?.trim().orEmpty()
+        if (!isYes(answer)) {
+            currentContext.fail("Aborted. File exists: $path")
+        }
     }
 }
 

--- a/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/command/index/dump/DumpRestorePaths.kt
+++ b/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/command/index/dump/DumpRestorePaths.kt
@@ -1,0 +1,20 @@
+package com.jillesvangurp.ktsearch.cli.command.index.dump
+
+internal fun parentDir(path: String): String {
+    val slash = path.lastIndexOf('/')
+    val backslash = path.lastIndexOf('\\')
+    val separatorIndex = maxOf(slash, backslash)
+    return if (separatorIndex < 0) "." else path.substring(0, separatorIndex)
+}
+
+internal fun joinPath(dir: String, name: String): String {
+    if (dir == "." || dir.isBlank()) {
+        return name
+    }
+    val separator = if (dir.contains('\\') && !dir.contains('/')) "\\" else "/"
+    return if (dir.endsWith('/') || dir.endsWith('\\')) {
+        "$dir$name"
+    } else {
+        "$dir$separator$name"
+    }
+}

--- a/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/command/index/dump/RestoreCommand.kt
+++ b/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/command/index/dump/RestoreCommand.kt
@@ -12,6 +12,7 @@ import com.github.ajalt.clikt.parameters.types.int
 import com.jillesvangurp.ktsearch.cli.CliPlatform
 import com.jillesvangurp.ktsearch.cli.CliService
 import com.jillesvangurp.ktsearch.cli.ConnectionOptions
+import com.jillesvangurp.ktsearch.cli.platformReadUtf8File
 
 class RestoreCommand(
     private val service: CliService,
@@ -71,6 +72,16 @@ class RestoreCommand(
         help = "Temporarily set index number_of_replicas to 0.",
     ).flag(default = false)
 
+    private val schema by option(
+        "--schema",
+        help = "Load <index>-schema.json and create target index from it.",
+    ).flag(default = false)
+
+    private val aliases by option(
+        "--aliases",
+        help = "Load <index>-aliases.json and apply aliases before restore.",
+    ).flag(default = false)
+
     private val yes by option(
         "-y",
         "--yes",
@@ -81,8 +92,28 @@ class RestoreCommand(
         val connectionOptions = currentContext.findObject<ConnectionOptions>()
             ?: error("Missing connection options in command context")
         val inputPath = input ?: "$index.ndjson.gz"
+        val inputDir = parentDir(inputPath)
+        val schemaPath = joinPath(inputDir, "$index-schema.json")
+        val aliasesPath = joinPath(inputDir, "$index-aliases.json")
+
         if (!platform.fileExists(inputPath)) {
             currentContext.fail("Input file does not exist: $inputPath")
+        }
+        val schemaJson = if (schema) {
+            if (!platform.fileExists(schemaPath)) {
+                currentContext.fail("Schema file does not exist: $schemaPath")
+            }
+            platformReadUtf8File(schemaPath)
+        } else {
+            null
+        }
+        val aliasesJson = if (aliases) {
+            if (!platform.fileExists(aliasesPath)) {
+                currentContext.fail("Aliases file does not exist: $aliasesPath")
+            }
+            platformReadUtf8File(aliasesPath)
+        } else {
+            null
         }
 
         if (recreate && !yes) {
@@ -113,6 +144,8 @@ class RestoreCommand(
                 idField = idField,
                 disableRefreshInterval = disableRefreshInterval,
                 setReplicasToZero = setReplicasToZero,
+                schemaJson = schemaJson,
+                aliasesJson = aliasesJson,
             )
         } finally {
             reader.close()

--- a/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/command/index/dump/RestoreCommand.kt
+++ b/ktsearch-cli/src/commonMain/kotlin/com/jillesvangurp/ktsearch/cli/command/index/dump/RestoreCommand.kt
@@ -58,10 +58,6 @@ class RestoreCommand(
         help = "Routing value for all restored docs.",
     )
 
-    private val idField by option(
-        "--id-field",
-        help = "Extract document id from this JSON field per line.",
-    )
     private val disableRefreshInterval by option(
         "--disable-refresh-interval",
         help = "Temporarily set index refresh_interval to -1.",
@@ -141,7 +137,6 @@ class RestoreCommand(
                 refresh = refresh,
                 pipeline = pipeline,
                 routing = routing,
-                idField = idField,
                 disableRefreshInterval = disableRefreshInterval,
                 setReplicasToZero = setReplicasToZero,
                 schemaJson = schemaJson,

--- a/ktsearch-cli/src/jvmTest/kotlin/com/jillesvangurp/ktsearch/cli/CliSchemaAliasSerializationTest.kt
+++ b/ktsearch-cli/src/jvmTest/kotlin/com/jillesvangurp/ktsearch/cli/CliSchemaAliasSerializationTest.kt
@@ -1,0 +1,79 @@
+package com.jillesvangurp.ktsearch.cli
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+
+class CliSchemaAliasSerializationTest {
+    @Test
+    fun composeSchemaJsonSanitizesImmutableSettings() {
+        val settingsRaw = """
+            {
+              "products": {
+                "settings": {
+                  "index": {
+                    "number_of_shards": "1",
+                    "routing_partition_size": "2",
+                    "provided_name": "products",
+                    "creation_date": "1",
+                    "uuid": "abc"
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+        val mappingsRaw = """
+            {
+              "products": {
+                "mappings": {
+                  "properties": {
+                    "title": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val actual = Json.parseToJsonElement(
+            composeSchemaJson("products", settingsRaw, mappingsRaw),
+        ).jsonObject
+
+        val indexSettings = actual["settings"]!!.jsonObject["index"]!!.jsonObject
+        indexSettings["number_of_shards"]?.toString() shouldBe "\"1\""
+        indexSettings["routing_partition_size"]?.toString() shouldBe "\"2\""
+        indexSettings["provided_name"] shouldBe null
+        indexSettings["creation_date"] shouldBe null
+        indexSettings["uuid"] shouldBe null
+        actual["mappings"]!!.jsonObject["properties"] shouldBe
+            Json.parseToJsonElement("""{"title":{"type":"keyword"}}""")
+    }
+
+    @Test
+    fun composeAliasActionsPreservesAliasProperties() {
+        val aliasesRaw = """
+            {
+              "products": {
+                "aliases": {
+                  "products-read": {
+                    "is_write_index": false
+                  },
+                  "products-write": {
+                    "is_write_index": true
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val actions = Json.parseToJsonElement(
+            composeAliasActions("products", aliasesRaw),
+        ).jsonObject["actions"]!!.toString()
+
+        actions.contains("\"alias\":\"products-read\"") shouldBe true
+        actions.contains("\"alias\":\"products-write\"") shouldBe true
+        actions.contains("\"is_write_index\":true") shouldBe true
+    }
+}

--- a/ktsearch-cli/src/jvmTest/kotlin/com/jillesvangurp/ktsearch/cli/CliSchemaAliasSerializationTest.kt
+++ b/ktsearch-cli/src/jvmTest/kotlin/com/jillesvangurp/ktsearch/cli/CliSchemaAliasSerializationTest.kt
@@ -2,6 +2,7 @@ package com.jillesvangurp.ktsearch.cli
 
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
+import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 
@@ -75,5 +76,21 @@ class CliSchemaAliasSerializationTest {
         actions.contains("\"alias\":\"products-read\"") shouldBe true
         actions.contains("\"alias\":\"products-write\"") shouldBe true
         actions.contains("\"is_write_index\":true") shouldBe true
+    }
+
+    @Test
+    fun parseDumpLineAcceptsWrappedFormat() {
+        val parsed = parseDumpLine("""{"_id":"42","_source":{"f":"v"}}""", 1)
+        parsed.id shouldBe "42"
+        parsed.source shouldBe """{"f":"v"}"""
+    }
+
+    @Test
+    fun parseDumpLineRejectsOldSourceOnlyFormat() {
+        val failure = runCatching {
+            parseDumpLine("""{"f":"v"}""", 7)
+        }.exceptionOrNull()
+
+        assertTrue(failure is com.github.ajalt.clikt.core.UsageError)
     }
 }

--- a/ktsearch-cli/src/jvmTest/kotlin/com/jillesvangurp/ktsearch/cli/KtSearchCliTest.kt
+++ b/ktsearch-cli/src/jvmTest/kotlin/com/jillesvangurp/ktsearch/cli/KtSearchCliTest.kt
@@ -11,6 +11,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.InputStreamReader
 import java.util.zip.GZIPInputStream
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.createTempFile
 import kotlin.test.Test
 import kotlin.time.Clock
@@ -121,6 +122,46 @@ class KtSearchCliTest {
 
         service.lastDumpedIndex shouldBe "products"
         platform.lastWriter.lines.size shouldBe 3
+    }
+
+    @Test
+    fun dumpExportsSchemaAndAliasesInOutputDirectory() = runTest {
+        val outputPath = createTempFile("ktsearch-dump-", ".ndjson.gz")
+            .absolutePathString()
+        File(outputPath).delete()
+        val outputDir = File(outputPath).parentFile
+        val schemaPath = File(outputDir, "products-schema.json")
+        val aliasesPath = File(outputDir, "products-aliases.json")
+        schemaPath.delete()
+        aliasesPath.delete()
+
+        val service = FakeService(
+            schemaExport = """{"settings":{"index":{"number_of_shards":"1"}}}""",
+            aliasesExport = """{"products":{"aliases":{"products-read":{}}}}""",
+        )
+        val platform = FakePlatform(
+            interactive = false,
+            existingPaths = mutableSetOf(outputPath),
+        )
+        val cmd = newCommand(service = service, platform = platform)
+
+        cmd.parse(
+            arrayOf(
+                "index",
+                "dump",
+                "products",
+                "--output",
+                outputPath,
+                "--schema",
+                "--aliases",
+                "--yes",
+            ),
+        )
+
+        schemaPath.exists() shouldBe true
+        aliasesPath.exists() shouldBe true
+        schemaPath.readText() shouldBe service.schemaExport
+        aliasesPath.readText() shouldBe service.aliasesExport
     }
 
     @Test
@@ -789,6 +830,8 @@ class KtSearchCliTest {
             idField = null,
             disableRefreshInterval = false,
             setReplicasToZero = false,
+            schemaJson = null,
+            aliasesJson = null,
             lines = listOf("""{"id":1}""", """{"id":2}"""),
         )
     }
@@ -817,6 +860,82 @@ class KtSearchCliTest {
 
         service.lastRestoreRequest?.disableRefreshInterval shouldBe true
         service.lastRestoreRequest?.setReplicasToZero shouldBe true
+    }
+
+    @Test
+    fun restoreForwardsSchemaAndAliases() = runTest {
+        val inputPath = createTempFile("ktsearch-restore-", ".ndjson.gz")
+            .absolutePathString()
+        File(inputPath).delete()
+        val inputDir = File(inputPath).parentFile
+        val schemaPath = File(inputDir, "products-schema.json")
+        val aliasesPath = File(inputDir, "products-aliases.json")
+        schemaPath.writeText("""{"settings":{"index":{"number_of_shards":"1"}}}""")
+        aliasesPath.writeText("""{"products":{"aliases":{"products-read":{}}}}""")
+
+        val service = FakeService()
+        val platform = FakePlatform(
+            interactive = false,
+            existingPaths = mutableSetOf(
+                inputPath,
+                schemaPath.absolutePath,
+                aliasesPath.absolutePath,
+            ),
+        ).apply {
+            nextReaderLines = listOf("""{"id":1}""")
+        }
+        val cmd = newCommand(service = service, platform = platform)
+
+        cmd.parse(
+            arrayOf(
+                "index",
+                "restore",
+                "products",
+                "--input",
+                inputPath,
+                "--schema",
+                "--aliases",
+                "--yes",
+            ),
+        )
+
+        service.lastRestoreRequest?.schemaJson shouldBe schemaPath.readText()
+        service.lastRestoreRequest?.aliasesJson shouldBe aliasesPath.readText()
+    }
+
+    @Test
+    fun restoreSchemaFailsWhenIndexExistsAndRecreateMissing() = runTest {
+        val inputPath = createTempFile("ktsearch-restore-", ".ndjson.gz")
+            .absolutePathString()
+        File(inputPath).delete()
+        val inputDir = File(inputPath).parentFile
+        val schemaPath = File(inputDir, "products-schema.json")
+        schemaPath.writeText("""{"settings":{"index":{"number_of_shards":"1"}}}""")
+
+        val service = FakeService(failOnSchemaWithoutRecreate = true)
+        val platform = FakePlatform(
+            interactive = false,
+            existingPaths = mutableSetOf(inputPath, schemaPath.absolutePath),
+        ).apply {
+            nextReaderLines = listOf("""{"id":1}""")
+        }
+        val cmd = newCommand(service = service, platform = platform)
+
+        val result = runCatching {
+            cmd.parse(
+                arrayOf(
+                    "index",
+                    "restore",
+                    "products",
+                    "--input",
+                    inputPath,
+                    "--schema",
+                    "--yes",
+                ),
+            )
+        }.exceptionOrNull()
+
+        (result is UsageError) shouldBe true
     }
 
     @Test
@@ -970,6 +1089,9 @@ private class FakeService(
     private val clusterHealthResponse: String = """
         {"cluster_name":"cluster","status":"green","timed_out":false}
     """.trimIndent(),
+    val schemaExport: String = """{"settings":{},"mappings":{}}""",
+    val aliasesExport: String = """{"products":{"aliases":{}}}""",
+    private val failOnSchemaWithoutRecreate: Boolean = false,
 ) : CliService {
     var lastConnectionOptions: ConnectionOptions? = null
     var lastDumpedIndex: String? = null
@@ -1019,6 +1141,24 @@ private class FakeService(
         lastDumpedIndex = index
         dumpLines.forEach { writer.writeLine(it) }
         return dumpLines.size.toLong()
+    }
+
+    override suspend fun exportIndexSchema(
+        connectionOptions: ConnectionOptions,
+        index: String,
+    ): String {
+        lastConnectionOptions = connectionOptions
+        lastDumpedIndex = index
+        return schemaExport
+    }
+
+    override suspend fun exportIndexAliases(
+        connectionOptions: ConnectionOptions,
+        index: String,
+    ): String {
+        lastConnectionOptions = connectionOptions
+        lastDumpedIndex = index
+        return aliasesExport
     }
 
     override suspend fun searchIndexRaw(
@@ -1111,8 +1251,16 @@ private class FakeService(
         idField: String?,
         disableRefreshInterval: Boolean,
         setReplicasToZero: Boolean,
+        schemaJson: String?,
+        aliasesJson: String?,
     ): Long {
         lastConnectionOptions = connectionOptions
+        if (failOnSchemaWithoutRecreate && schemaJson != null && !recreate) {
+            throw UsageError(
+                "Target index '$index' already exists. " +
+                    "Use --recreate with --schema.",
+            )
+        }
         val lines = mutableListOf<String>()
         while (true) {
             val line = reader.readLine() ?: break
@@ -1129,6 +1277,8 @@ private class FakeService(
             idField = idField,
             disableRefreshInterval = disableRefreshInterval,
             setReplicasToZero = setReplicasToZero,
+            schemaJson = schemaJson,
+            aliasesJson = aliasesJson,
             lines = lines,
         )
         return lines.size.toLong()
@@ -1211,6 +1361,8 @@ private data class RestoreRequest(
     val idField: String?,
     val disableRefreshInterval: Boolean,
     val setReplicasToZero: Boolean,
+    val schemaJson: String?,
+    val aliasesJson: String?,
     val lines: List<String>,
 )
 

--- a/ktsearch-cli/src/jvmTest/kotlin/com/jillesvangurp/ktsearch/cli/KtSearchCliTest.kt
+++ b/ktsearch-cli/src/jvmTest/kotlin/com/jillesvangurp/ktsearch/cli/KtSearchCliTest.kt
@@ -804,7 +804,10 @@ class KtSearchCliTest {
             interactive = false,
             existingPaths = mutableSetOf("products.ndjson.gz"),
         ).apply {
-            nextReaderLines = listOf("""{"id":1}""", """{"id":2}""")
+            nextReaderLines = listOf(
+                """{"_id":"1","_source":{"id":1}}""",
+                """{"_id":"2","_source":{"id":2}}""",
+            )
         }
         val cmd = newCommand(service = service, platform = platform)
 
@@ -827,12 +830,14 @@ class KtSearchCliTest {
             refresh = "wait_for",
             pipeline = null,
             routing = null,
-            idField = null,
             disableRefreshInterval = false,
             setReplicasToZero = false,
             schemaJson = null,
             aliasesJson = null,
-            lines = listOf("""{"id":1}""", """{"id":2}"""),
+            lines = listOf(
+                """{"_id":"1","_source":{"id":1}}""",
+                """{"_id":"2","_source":{"id":2}}""",
+            ),
         )
     }
 
@@ -843,7 +848,7 @@ class KtSearchCliTest {
             interactive = false,
             existingPaths = mutableSetOf("products.ndjson.gz"),
         ).apply {
-            nextReaderLines = listOf("""{"id":1}""")
+            nextReaderLines = listOf("""{"_id":"1","_source":{"id":1}}""")
         }
         val cmd = newCommand(service = service, platform = platform)
 
@@ -882,7 +887,7 @@ class KtSearchCliTest {
                 aliasesPath.absolutePath,
             ),
         ).apply {
-            nextReaderLines = listOf("""{"id":1}""")
+            nextReaderLines = listOf("""{"_id":"1","_source":{"id":1}}""")
         }
         val cmd = newCommand(service = service, platform = platform)
 
@@ -917,7 +922,7 @@ class KtSearchCliTest {
             interactive = false,
             existingPaths = mutableSetOf(inputPath, schemaPath.absolutePath),
         ).apply {
-            nextReaderLines = listOf("""{"id":1}""")
+            nextReaderLines = listOf("""{"_id":"1","_source":{"id":1}}""")
         }
         val cmd = newCommand(service = service, platform = platform)
 
@@ -1089,6 +1094,7 @@ private class FakeService(
     private val clusterHealthResponse: String = """
         {"cluster_name":"cluster","status":"green","timed_out":false}
     """.trimIndent(),
+    private val dumpHitId: String = "1",
     val schemaExport: String = """{"settings":{},"mappings":{}}""",
     val aliasesExport: String = """{"products":{"aliases":{}}}""",
     private val failOnSchemaWithoutRecreate: Boolean = false,
@@ -1139,7 +1145,9 @@ private class FakeService(
     ): Long {
         lastConnectionOptions = connectionOptions
         lastDumpedIndex = index
-        dumpLines.forEach { writer.writeLine(it) }
+        dumpLines.forEach { sourceLine ->
+            writer.writeLine("""{"_id":"$dumpHitId","_source":$sourceLine}""")
+        }
         return dumpLines.size.toLong()
     }
 
@@ -1248,7 +1256,6 @@ private class FakeService(
         refresh: String,
         pipeline: String?,
         routing: String?,
-        idField: String?,
         disableRefreshInterval: Boolean,
         setReplicasToZero: Boolean,
         schemaJson: String?,
@@ -1274,7 +1281,6 @@ private class FakeService(
             refresh = refresh,
             pipeline = pipeline,
             routing = routing,
-            idField = idField,
             disableRefreshInterval = disableRefreshInterval,
             setReplicasToZero = setReplicasToZero,
             schemaJson = schemaJson,
@@ -1358,7 +1364,6 @@ private data class RestoreRequest(
     val refresh: String,
     val pipeline: String?,
     val routing: String?,
-    val idField: String?,
     val disableRefreshInterval: Boolean,
     val setReplicasToZero: Boolean,
     val schemaJson: String?,


### PR DESCRIPTION
Summary
- extend `ktsearch index dump/restore` with optional schema and alias sidecar handling, keeping defaults unchanged
- switch NDJSON dump format to include `_id`/`_source` so restore can rely on explicit IDs and remove `--id-field`
- wire CLI flags through `CliService`, generate schema/alias files, and update docs/tests to cover the new behavior

Testing
- Not run (not requested)